### PR TITLE
Add plasma lava lamp animation

### DIFF
--- a/backend/animations/animate.go
+++ b/backend/animations/animate.go
@@ -186,6 +186,24 @@ func appendAnimatorsForAction(animators *[]segActionAndAnimator, seg SegmentActi
 	case "Twinkle":
 		*animators = append(*animators, segActionAndAnimator{seg, newTwinkle()})
 
+	case "Plasma":
+		var err error
+		speed, err := seg.Params.asRange(0)
+		var brightness int
+		if err == nil {
+			brightness, err = seg.Params.asRange(1)
+		}
+		var palette int
+		if err == nil {
+			palette, err = seg.Params.asRange(2)
+		}
+		if err == nil {
+			*animators = append(*animators,
+				segActionAndAnimator{seg, newPlasma(float64(speed), brightness, palette)})
+		} else {
+			log.WithFields(log.Fields{"params": seg.Params, "Error": err.Error()}).Warn("Bad animation parameter")
+		}
+
 	case "Baby Bows":
 		var err error
 		length, err := seg.Params.asRange(0)

--- a/backend/animations/plasma.go
+++ b/backend/animations/plasma.go
@@ -1,0 +1,58 @@
+package animations
+
+import (
+	"math"
+
+	"github.com/andew42/brightlight/framebuffer"
+	"github.com/andew42/brightlight/segment"
+)
+
+type plasma struct {
+	speed      float64
+	brightness int
+	palette    int // 0=rainbow, 1=fire, 2=ocean, 3=forest
+}
+
+func newPlasma(speed float64, brightness int, palette int) *plasma {
+	return &plasma{
+		speed:      speed,
+		brightness: brightness,
+		palette:    palette,
+	}
+}
+
+func (p *plasma) animateFrame(frameCount uint, frame segment.Segment) {
+	t := float64(frameCount) * p.speed * 0.01
+
+	for i := uint(0); i < frame.Len(); i++ {
+		pos := float64(i) / float64(frame.Len())
+
+		wave1 := math.Sin(pos*10.0 + t)
+		wave2 := math.Sin(pos*8.0 - t*0.7)
+		wave3 := math.Cos(pos*6.0 + t*0.5)
+		wave4 := math.Sin(pos*12.0 - t*0.3)
+
+		plasma := (wave1 + wave2 + wave3 + wave4) / 4.0
+		normalized := (plasma + 1.0) / 2.0
+
+		var hue uint
+		var saturation uint
+
+		switch p.palette {
+		case 1: // Fire (red-orange-yellow)
+			hue = uint(normalized * 60.0)
+			saturation = 100
+		case 2: // Ocean (blue-cyan-green)
+			hue = uint(180.0 + normalized*60.0)
+			saturation = 80
+		case 3: // Forest (green shades)
+			hue = uint(90.0 + normalized*60.0)
+			saturation = 70
+		default: // Rainbow
+			hue = uint(normalized * 360.0)
+			saturation = 100
+		}
+
+		frame.Set(i, framebuffer.NewRgbFromHsl(hue, saturation, uint(p.brightness)))
+	}
+}

--- a/frontend/public/ui-config/default-buttons.json
+++ b/frontend/public/ui-config/default-buttons.json
@@ -145,14 +145,16 @@
     },
     {
       "key": 11,
-      "name": "",
+      "name": "Plasma Lava Lamp",
       "segments": [
         {
           "name": "All",
           "z": 1,
-          "animation": "Static",
+          "animation": "Plasma",
           "params": [
-            {"key": 20, "type": "colour", "label": "Colour", "value": {"r": 0, "g": 0, "b": 0}}
+            {"key": 110, "type": "range", "label": "Speed", "min": 1, "max": 100, "value": 50},
+            {"key": 111, "type": "range", "label": "Brightness", "min": 10, "max": 60, "value": 50},
+            {"key": 112, "type": "range", "label": "Palette", "min": 0, "max": 3, "value": 0}
           ]
         }
       ]


### PR DESCRIPTION
## Summary
- Adds `backend/animations/plasma.go` — a lava-lamp-style plasma effect with configurable speed, brightness, and palette (rainbow / fire / ocean / forest)
- Wires the `Plasma` animation case into `backend/animations/animate.go`
- Updates button 11 in `frontend/public/ui-config/default-buttons.json` to use the new animation

Supersedes #35 — that PR had path conflicts because the original branch referenced the old flat repo layout (`animations/`, `ui2/`). This branch ports the same changes to the current structure.

## Test plan
- [ ] Start the backend and confirm the "Plasma Lava Lamp" button appears in the UI
- [ ] Verify each palette option (rainbow, fire, ocean, forest) renders correctly
- [ ] Confirm speed and brightness controls behave as expected
- [ ] Ensure no regressions in existing animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)