### PR TITLE
Add Alexa voice control of ui2 buttons

### DIFF
--- a/alexa/interaction-model.json
+++ b/alexa/interaction-model.json
@@ -1,0 +1,52 @@
+{
+  "interactionModel": {
+    "languageModel": {
+      "invocationName": "bedroom lights",
+      "intents": [
+        {
+          "name": "RunButtonIntent",
+          "slots": [
+            {
+              "name": "buttonName",
+              "type": "BUTTON_NAME"
+            }
+          ],
+          "samples": [
+            "{buttonName}",
+            "for {buttonName}",
+            "to run {buttonName}",
+            "run {buttonName}",
+            "to set {buttonName}",
+            "set {buttonName}"
+          ]
+        },
+        { "name": "AMAZON.HelpIntent", "samples": [] },
+        { "name": "AMAZON.StopIntent", "samples": [] },
+        { "name": "AMAZON.CancelIntent", "samples": [] },
+        { "name": "AMAZON.NavigateHomeIntent", "samples": [] },
+        { "name": "AMAZON.FallbackIntent", "samples": [] }
+      ],
+      "types": [
+        {
+          "name": "BUTTON_NAME",
+          "values": [
+            { "name": { "value": "off" } },
+            { "name": { "value": "full" } },
+            { "name": { "value": "low" } },
+            { "name": { "value": "mid" } },
+            { "name": { "value": "high" } },
+            { "name": { "value": "nearly off" } },
+            { "name": { "value": "sweet shop" } },
+            { "name": { "value": "twinkle" } },
+            { "name": { "value": "baby bows" } },
+            { "name": { "value": "runner" } },
+            { "name": { "value": "rainbow" } },
+            { "name": { "value": "one" } },
+            { "name": { "value": "two" } },
+            { "name": { "value": "three" } }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/alexa/lambda/.gitignore
+++ b/alexa/lambda/.gitignore
@@ -1,0 +1,4 @@
+lambda
+bootstrap
+lambda.zip
+server-cert.pem

--- a/alexa/lambda/go.mod
+++ b/alexa/lambda/go.mod
@@ -1,0 +1,5 @@
+module github.com/andew42/brightlight/alexa/lambda
+
+go 1.24.7
+
+require github.com/aws/aws-lambda-go v1.54.0 // indirect

--- a/alexa/lambda/go.sum
+++ b/alexa/lambda/go.sum
@@ -1,0 +1,2 @@
+github.com/aws/aws-lambda-go v1.54.0 h1:EGYpdyRGF88xszqlGcBewz811mJeRS+maNlLZXFheII=
+github.com/aws/aws-lambda-go v1.54.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=

--- a/alexa/lambda/main.go
+++ b/alexa/lambda/main.go
@@ -1,0 +1,164 @@
+// Lambda handler for the brightlight Alexa custom skill. Forwards the
+// spoken button name to the brightlight /alexa/RunButton endpoint over
+// HTTPS with a bearer token, trusting only the pinned brightlight
+// self-signed certificate.
+//
+// Environment variables:
+//
+//	BRIGHTLIGHT_URL         e.g. https://myhouse.example.com:8443
+//	BRIGHTLIGHT_ALEXA_TOKEN shared secret, same value as on the server
+//	BRIGHTLIGHT_SERVER_CERT path to the server's PEM cert bundled in the
+//	                        zip (default server-cert.pem)
+//	ALEXA_SKILL_ID          if set, requests from other skills are refused
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+type alexaRequest struct {
+	Session struct {
+		Application struct {
+			ApplicationID string `json:"applicationId"`
+		} `json:"application"`
+	} `json:"session"`
+	Request struct {
+		Type   string `json:"type"`
+		Intent struct {
+			Name  string `json:"name"`
+			Slots map[string]struct {
+				Value string `json:"value"`
+			} `json:"slots"`
+		} `json:"intent"`
+	} `json:"request"`
+}
+
+type alexaResponse struct {
+	Version  string `json:"version"`
+	Response struct {
+		OutputSpeech struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"outputSpeech"`
+		ShouldEndSession bool `json:"shouldEndSession"`
+	} `json:"response"`
+}
+
+func speak(text string, endSession bool) alexaResponse {
+
+	var r alexaResponse
+	r.Version = "1.0"
+	r.Response.OutputSpeech.Type = "PlainText"
+	r.Response.OutputSpeech.Text = text
+	r.Response.ShouldEndSession = endSession
+	return r
+}
+
+func handle(ctx context.Context, request alexaRequest) (alexaResponse, error) {
+
+	if skillId := os.Getenv("ALEXA_SKILL_ID"); skillId != "" &&
+		request.Session.Application.ApplicationID != skillId {
+		return alexaResponse{}, errors.New("request from unexpected skill id")
+	}
+
+	switch request.Request.Type {
+
+	case "LaunchRequest":
+		return speak("Which light setting would you like?", false), nil
+
+	case "IntentRequest":
+		switch request.Request.Intent.Name {
+
+		case "RunButtonIntent":
+			buttonName := request.Request.Intent.Slots["buttonName"].Value
+			if buttonName == "" {
+				return speak("Which light setting would you like?", false), nil
+			}
+			return runButton(buttonName), nil
+
+		case "AMAZON.HelpIntent":
+			return speak("Say the name of a light setting, for example rainbow.", false), nil
+
+		default: // AMAZON.StopIntent, AMAZON.CancelIntent etc.
+			return speak("Goodbye.", true), nil
+		}
+
+	default: // SessionEndedRequest must not include speech
+		var r alexaResponse
+		r.Version = "1.0"
+		r.Response.ShouldEndSession = true
+		return r, nil
+	}
+}
+
+// Call the brightlight RunButton endpoint and turn the result into speech
+func runButton(buttonName string) alexaResponse {
+
+	client, err := newPinnedClient()
+	if err != nil {
+		return speak("The light server certificate is not configured.", true)
+	}
+
+	body, _ := json.Marshal(struct {
+		Button string `json:"button"`
+	}{buttonName})
+
+	url := os.Getenv("BRIGHTLIGHT_URL") + "/alexa/RunButton"
+	request, _ := http.NewRequest("POST", url, bytes.NewReader(body))
+	request.Header.Set("Authorization", "Bearer "+os.Getenv("BRIGHTLIGHT_ALEXA_TOKEN"))
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := client.Do(request)
+	if err != nil {
+		return speak("I couldn't reach the light server.", true)
+	}
+	defer response.Body.Close()
+
+	switch response.StatusCode {
+	case 200:
+		var result struct{ Matched string }
+		if json.NewDecoder(response.Body).Decode(&result) == nil && result.Matched != "" {
+			return speak("OK, "+result.Matched+".", true)
+		}
+		return speak("OK.", true)
+	case 404:
+		return speak("I couldn't find a light setting called "+buttonName+".", true)
+	default:
+		return speak("The light server said no. Check its logs.", true)
+	}
+}
+
+// HTTP client trusting only the brightlight self-signed certificate
+func newPinnedClient() (*http.Client, error) {
+
+	certPath := os.Getenv("BRIGHTLIGHT_SERVER_CERT")
+	if certPath == "" {
+		certPath = "server-cert.pem"
+	}
+	pem, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, err
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, errors.New("no certificate found in " + certPath)
+	}
+	return &http.Client{
+		Timeout:   6 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}},
+	}, nil
+}
+
+func main() {
+	lambda.Start(handle)
+}

--- a/alexa/readme.md
+++ b/alexa/readme.md
@@ -1,0 +1,100 @@
+# Alexa voice control
+
+Voice phrasing: **"Alexa, ask bedroom lights for rainbow"** (also "... to run
+rainbow", or just "Alexa, ask bedroom lights" then say the setting name).
+The spoken name is matched case-insensitively against the button names in
+`backend/ui-config/user-buttons.json` (fallback `default-buttons.json`),
+with small speech-to-text errors forgiven and spoken numbers matched to
+digits ("two tone" finds "2 Tone").
+
+```
+Alexa -> custom skill -> AWS Lambda (this directory)
+      -> HTTPS + bearer token + pinned cert -> brightlight /alexa/RunButton
+```
+
+See `docs/alexa-integration-plan.md` for the design discussion.
+
+## 1. Generate a shared token and server certificate
+
+On the brightlight box:
+
+```sh
+# 64 char random token
+openssl rand -hex 32 > alexa-token.txt
+
+# 10 year self-signed cert; CN/SAN must be the public hostname the Lambda
+# will connect to (your DDNS name)
+openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+  -keyout alexa-key.pem -out alexa-cert.pem \
+  -subj "/CN=myhouse.example.com" \
+  -addext "subjectAltName=DNS:myhouse.example.com"
+```
+
+Keep `alexa-key.pem` and the token private and outside the web content tree.
+
+## 2. Configure brightlight
+
+Set the environment variables before starting brightlight (the Alexa
+listener is disabled when `BRIGHTLIGHT_ALEXA_TOKEN` is unset):
+
+| Variable | Value |
+|---|---|
+| `BRIGHTLIGHT_ALEXA_TOKEN` | contents of alexa-token.txt |
+| `BRIGHTLIGHT_ALEXA_CERT` | path to alexa-cert.pem |
+| `BRIGHTLIGHT_ALEXA_KEY` | path to alexa-key.pem |
+| `BRIGHTLIGHT_ALEXA_PORT` | optional, default 8443 |
+
+Forward exactly one port on the router: external 8443 to the brightlight
+box port 8443. Do not forward 8080.
+
+Test from anywhere:
+
+```sh
+curl --cacert alexa-cert.pem \
+  -H "Authorization: Bearer $(cat alexa-token.txt)" \
+  https://myhouse.example.com:8443/alexa/Buttons
+
+curl --cacert alexa-cert.pem \
+  -H "Authorization: Bearer $(cat alexa-token.txt)" \
+  -d '{"button":"rainbow"}' \
+  https://myhouse.example.com:8443/alexa/RunButton
+```
+
+## 3. Build and deploy the Lambda
+
+```sh
+cd alexa/lambda
+GOOS=linux GOARCH=arm64 go build -o bootstrap .
+cp /path/to/alexa-cert.pem server-cert.pem
+zip lambda.zip bootstrap server-cert.pem
+```
+
+In the AWS console create a Lambda: runtime **provided.al2023**,
+architecture arm64, upload `lambda.zip`. Set environment variables:
+
+| Variable | Value |
+|---|---|
+| `BRIGHTLIGHT_URL` | `https://myhouse.example.com:8443` |
+| `BRIGHTLIGHT_ALEXA_TOKEN` | same token as the server |
+| `ALEXA_SKILL_ID` | skill id from step 4 (add after creating the skill) |
+
+Add an **Alexa Skills Kit** trigger with the skill id.
+
+## 4. Create the skill
+
+In the [Alexa developer console](https://developer.amazon.com/alexa/console/ask)
+create a **Custom** skill named e.g. "Bedroom Lights", then in the JSON
+editor paste `interaction-model.json` and build the model. Set the
+endpoint to the Lambda's ARN. Copy the skill id into the Lambda
+environment and trigger.
+
+The skill stays in development mode, which is fine for personal use on
+devices signed in to the same Amazon account.
+
+## 5. Keeping button names recognisable
+
+The `BUTTON_NAME` slot values are recognition hints, not a closed list.
+When you add or rename buttons, fetch the current names with
+`GET /alexa/Buttons` and paste them into the slot values in the developer
+console for best recognition. Unlisted names usually still work if they
+are ordinary English words.

--- a/backend/main.go
+++ b/backend/main.go
@@ -96,6 +96,10 @@ func main() {
 	http.HandleFunc("/api/Stats", servers.StatsHandler)
 	http.HandleFunc("/api/option/", servers.OptionHandler)
 
+	// Alexa voice control endpoint (HTTPS on its own port, disabled unless
+	// BRIGHTLIGHT_ALEXA_TOKEN is set)
+	servers.StartAlexaServer(uiConfigDir)
+
 	// Set up static content serving (skipped when BRIGHTLIGHT is unset — Vite serves the frontend)
 	if len(contentBasePath) > 0 {
 		err := mime.AddExtensionType(".manifest", "text/cache-manifest")

--- a/backend/servers/alexa.go
+++ b/backend/servers/alexa.go
@@ -1,0 +1,251 @@
+package servers
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/andew42/brightlight/animations"
+)
+
+// Alexa voice control endpoints, served over HTTPS on a separate port with
+// a separate mux so only these two routes are ever exposed through the
+// router. The feature is opt-in: if BRIGHTLIGHT_ALEXA_TOKEN is unset the
+// listener is not started at all.
+//
+//	POST /alexa/RunButton {"button":"sweet shop"} -> runs the button
+//	GET  /alexa/Buttons                           -> lists button names
+
+// StartAlexaServer Start the Alexa HTTPS listener if configured.
+// uiConfigDir is the filesystem path to the ui-config directory.
+func StartAlexaServer(uiConfigDir string) {
+
+	token := os.Getenv("BRIGHTLIGHT_ALEXA_TOKEN")
+	if token == "" {
+		slog.Info("BRIGHTLIGHT_ALEXA_TOKEN not set, Alexa endpoint disabled")
+		return
+	}
+	if len(token) < 32 {
+		slog.Warn("BRIGHTLIGHT_ALEXA_TOKEN is short, use at least 32 random characters")
+	}
+
+	certPath := os.Getenv("BRIGHTLIGHT_ALEXA_CERT")
+	keyPath := os.Getenv("BRIGHTLIGHT_ALEXA_KEY")
+	if certPath == "" || keyPath == "" {
+		slog.Error("BRIGHTLIGHT_ALEXA_CERT or BRIGHTLIGHT_ALEXA_KEY not set, Alexa endpoint disabled")
+		return
+	}
+
+	port := os.Getenv("BRIGHTLIGHT_ALEXA_PORT")
+	if port == "" {
+		port = "8443"
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/alexa/RunButton", requireAlexaToken(token, getRunButtonHandler(uiConfigDir)))
+	mux.HandleFunc("/alexa/Buttons", requireAlexaToken(token, getButtonsHandler(uiConfigDir)))
+
+	go func() {
+		slog.Info("serving Alexa endpoint", "port", port)
+		err := http.ListenAndServeTLS(":"+port, certPath, keyPath, mux)
+		slog.Error("Alexa server exited", "err", err)
+	}()
+}
+
+// Reject requests without the expected bearer token
+func requireAlexaToken(token string, handler http.HandlerFunc) http.HandlerFunc {
+
+	expected := []byte("Bearer " + token)
+	return func(w http.ResponseWriter, r *http.Request) {
+		supplied := []byte(r.Header.Get("Authorization"))
+		if subtle.ConstantTimeCompare(supplied, expected) != 1 {
+			slog.Warn("Alexa request with bad token", "remote", r.RemoteAddr)
+			http.Error(w, "unauthorized", 401)
+			return
+		}
+		handler(w, r)
+	}
+}
+
+// The button file also contains user segments which we ignore here
+type buttonFileDef struct {
+	Buttons []animations.Button
+}
+
+// Load buttons, preferring user buttons over defaults
+func loadButtons(uiConfigDir string) ([]animations.Button, error) {
+
+	content, err := os.ReadFile(filepath.Join(uiConfigDir, "user-buttons.json"))
+	if err != nil {
+		if content, err = os.ReadFile(filepath.Join(uiConfigDir, "default-buttons.json")); err != nil {
+			return nil, err
+		}
+	}
+
+	var buttonFile buttonFileDef
+	if err = json.Unmarshal(content, &buttonFile); err != nil {
+		return nil, err
+	}
+	return buttonFile.Buttons, nil
+}
+
+// Spoken numbers arrive as words but buttons may be named with digits
+var alexaWordDigits = map[string]string{
+	"zero": "0", "one": "1", "two": "2", "three": "3", "four": "4",
+	"five": "5", "six": "6", "seven": "7", "eight": "8", "nine": "9", "ten": "10",
+}
+
+// Reduce a name to a canonical form for matching: lower case, punctuation
+// stripped, whitespace collapsed and number words replaced with digits so
+// e.g. "Two Tone!" and "2 tone" both become "2 tone"
+func canonicaliseButtonName(name string) string {
+
+	mapped := strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return unicode.ToLower(r)
+		}
+		return ' '
+	}, name)
+
+	words := strings.Fields(mapped)
+	for i, w := range words {
+		if digit, ok := alexaWordDigits[w]; ok {
+			words[i] = digit
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+// Levenshtein edit distance, used to forgive small speech to text errors
+func editDistance(a string, b string) int {
+
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(curr[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}
+
+// Find the button best matching a spoken name, exact canonical match first
+// then closest edit distance within a small threshold
+func findButtonByName(buttons []animations.Button, spoken string) *animations.Button {
+
+	target := canonicaliseButtonName(spoken)
+	if target == "" {
+		return nil
+	}
+
+	for i := range buttons {
+		if canonicaliseButtonName(buttons[i].Name) == target {
+			return &buttons[i]
+		}
+	}
+
+	// Allow up to 2 edits but never more than a quarter of the name so short
+	// names like "off" don't match "on"
+	best := -1
+	bestDistance := 3
+	for i := range buttons {
+		name := canonicaliseButtonName(buttons[i].Name)
+		if name == "" {
+			continue
+		}
+		maxAllowed := min(2, len(name)/4)
+		if d := editDistance(name, target); d <= maxAllowed && d < bestDistance {
+			best, bestDistance = i, d
+		}
+	}
+	if best < 0 {
+		return nil
+	}
+	return &buttons[best]
+}
+
+// Handle POST /alexa/RunButton {"button":"name"}
+func getRunButtonHandler(uiConfigDir string) http.HandlerFunc {
+
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		if r.Method != "POST" {
+			http.Error(w, "method not allowed", 405)
+			return
+		}
+
+		var request struct {
+			Button string
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1024)).Decode(&request); err != nil {
+			slog.Warn("RunButton bad body", "err", err.Error())
+			http.Error(w, "bad request", 400)
+			return
+		}
+
+		buttons, err := loadButtons(uiConfigDir)
+		if err != nil {
+			slog.Error("RunButton failed to load buttons", "err", err.Error())
+			http.Error(w, "failed to load buttons", 500)
+			return
+		}
+
+		button := findButtonByName(buttons, request.Button)
+		if button == nil {
+			slog.Info("RunButton no matching button", "button", request.Button)
+			http.Error(w, "button not found", 404)
+			return
+		}
+		slog.Info("RunButton called", "heard", request.Button, "matched", button.Name)
+
+		// Run the animation and keep UI button pads in sync
+		animations.RunAnimations(button.Segments)
+		updateActiveButtonKey(button.Key)
+
+		w.Header().Set("Content-Type", "application/json")
+		response, _ := json.Marshal(struct{ Matched string }{button.Name})
+		if _, err = w.Write(response); err != nil {
+			slog.Warn("RunButton failed to write response", "err", err.Error())
+		}
+	}
+}
+
+// Handle GET /alexa/Buttons returning a JSON array of button names
+func getButtonsHandler(uiConfigDir string) http.HandlerFunc {
+
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		buttons, err := loadButtons(uiConfigDir)
+		if err != nil {
+			slog.Error("Buttons failed to load buttons", "err", err.Error())
+			http.Error(w, "failed to load buttons", 500)
+			return
+		}
+
+		names := make([]string, 0, len(buttons))
+		for _, b := range buttons {
+			if b.Name != "" {
+				names = append(names, b.Name)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		response, _ := json.Marshal(names)
+		if _, err = w.Write(response); err != nil {
+			slog.Warn("Buttons failed to write response", "err", err.Error())
+		}
+	}
+}

--- a/backend/servers/alexa_test.go
+++ b/backend/servers/alexa_test.go
@@ -1,0 +1,64 @@
+package servers
+
+import (
+	"github.com/andew42/brightlight/animations"
+	"testing"
+)
+
+func namedButtons(names ...string) []animations.Button {
+
+	buttons := make([]animations.Button, len(names))
+	for i, n := range names {
+		buttons[i] = animations.Button{Key: i + 1, Name: n}
+	}
+	return buttons
+}
+
+func TestCanonicaliseButtonName(t *testing.T) {
+
+	cases := map[string]string{
+		"Sweet Shop": "sweet shop",
+		"  OFF ":     "off",
+		"Two Tone!":  "2 tone",
+		"2 tone":     "2 tone",
+		"Baby-Bows":  "baby bows",
+		"":           "",
+		"Three":      "3",
+	}
+	for in, want := range cases {
+		if got := canonicaliseButtonName(in); got != want {
+			t.Errorf("canonicaliseButtonName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFindButtonByName(t *testing.T) {
+
+	buttons := namedButtons("OFF", "Full", "Sweet Shop", "Two Tone", "Rainbow", "One")
+
+	cases := map[string]string{
+		"off":        "OFF",
+		"sweet shop": "Sweet Shop",
+		"Sweet Shop": "Sweet Shop",
+		"two tone":   "Two Tone", // spoken "two" matches button "Two"
+		"2 tone":     "Two Tone",
+		"rainbows":   "Rainbow", // small speech to text error forgiven
+		"sweet shot": "Sweet Shop",
+		"1":          "One", // digit heard, word named button
+	}
+	for spoken, want := range cases {
+		b := findButtonByName(buttons, spoken)
+		if b == nil {
+			t.Errorf("findButtonByName(%q) = nil, want %q", spoken, want)
+		} else if b.Name != want {
+			t.Errorf("findButtonByName(%q) = %q, want %q", spoken, b.Name, want)
+		}
+	}
+
+	// Short names must not fuzzy match each other or gibberish
+	for _, spoken := range []string{"on", "disco", ""} {
+		if b := findButtonByName(buttons, spoken); b != nil {
+			t.Errorf("findButtonByName(%q) = %q, want no match", spoken, b.Name)
+		}
+	}
+}

--- a/docs/alexa-integration-plan.md
+++ b/docs/alexa-integration-plan.md
@@ -141,6 +141,14 @@ speakable button names, not code.
    server (including config PUT, which writes files) to the internet, and Alexa knows
    button *names*, not the full segment payload that endpoint requires.
 
+## Decisions (agreed 2026-07-12)
+
+Inbound HTTPS with port-forward; ui2 `user-buttons.json` (fallback
+`default-buttons.json`) is the only button source; simple Go Lambda with manual slot
+sync (no dynamic entities); "ask" as the connecting word ("Alexa, ask bedroom lights
+for rainbow"); fuzzy matching includes digit/word equivalence ("2" = "two").
+Implemented in `servers/alexa.go` and `alexa/`; deployment steps in `alexa/readme.md`.
+
 ## Open questions to agree before coding
 
 1. Inbound HTTPS + port-forward (this plan) vs outbound MQTT (alternative 2)?

--- a/docs/alexa-integration-plan.md
+++ b/docs/alexa-integration-plan.md
@@ -1,0 +1,133 @@
+# Alexa Light Control — Integration Plan
+
+Goal: say something like *"Alexa, tell bedroom lights rainbow"* and have brightlight run
+the button of that name, exactly as if it had been pressed in the UI.
+
+Guiding principles: **minimal new code**, **reuse the existing button/animation pipeline**,
+**never expose the existing UI/config endpoints to the internet**.
+
+## Architecture overview
+
+```
+ "Alexa, tell bedroom lights rainbow"
+        │
+        ▼
+ Alexa Custom Skill ("bedroom lights")
+   RunButtonIntent, slot {buttonName}
+        │
+        ▼
+ AWS Lambda (alexa/ in this repo)
+   POST https://<home-ddns>:8443/alexa/RunButton
+   Authorization: Bearer <shared secret>
+   TLS: pinned self-signed cert
+        │  (router forwards one port only)
+        ▼
+ brightlight (new HTTPS listener, separate mux, port 8443)
+   servers/alexa.go
+     - verify bearer token (constant-time)
+     - look up button by name in ui2/build/ui-config/user-buttons.json
+       (fallback default-buttons.json)
+     - animations.RunAnimations(button.Segments)
+     - updateActiveButtonKey(button.Key)   → UIs stay in sync
+```
+
+## Part 1 — brightlight (Go)
+
+One new file, `servers/alexa.go`, plus a few lines in `main.go`.
+
+### New endpoints (on a *separate* mux/port, never the existing one)
+
+| Route | Method | Purpose |
+|---|---|---|
+| `/alexa/RunButton` | POST `{"button":"rainbow"}` | Case-insensitive button name match → run it |
+| `/alexa/Buttons` | GET | List button names (debugging / keeping the skill slot list in sync) |
+
+Implementation notes:
+
+* The ui2 button file (`user-buttons.json` / `default-buttons.json`) already has the exact
+  shape of `animations.Button` (`key`, `name`, `segments`), so the handler is: read file,
+  unmarshal `{ "buttons": []animations.Button }`, find name (case-insensitive, trimmed),
+  call `animations.RunAnimations(...)` and `updateActiveButtonKey(...)` — the same two
+  calls `RunAnimationsHandler` makes today. No new animation code at all.
+* Reading the file per request (like the config handler does) keeps it simple and always
+  picks up button edits — no cache invalidation logic needed. It's one small file read per
+  voice command; performance is irrelevant here.
+
+### Security
+
+* **Separate listener**: `http.ListenAndServeTLS` on its own port (e.g. 8443) with its own
+  `http.ServeMux` containing *only* the two Alexa routes. The existing HTTP server (UI,
+  config PUT, websockets) remains LAN-only and untouched. The router forwards only 8443.
+* **Bearer token**: a long random secret loaded from an environment variable
+  (e.g. `BRIGHTLIGHT_ALEXA_TOKEN`) or a file *outside* the served content tree. Compared
+  with `crypto/subtle.ConstantTimeCompare`. Missing token at startup → Alexa listener is
+  simply not started (feature is opt-in).
+* **TLS with a pinned self-signed cert**: generate a long-lived self-signed cert once;
+  the Lambda bundles the public cert and uses it as its only trust root. This gives
+  encryption *and* server authentication without a domain, Let's Encrypt, or renewal
+  plumbing — and the Lambda will refuse to talk to anything that isn't our box.
+* **Failures logged** via the existing logrus setup (bad token, unknown button), returning
+  401/404 with no detail in the body.
+
+Worst case if the token ever leaked: an attacker can change your light colours. No config
+writes, no file access, no UI exposure.
+
+## Part 2 — Alexa skill + Lambda (`alexa/` directory in this repo)
+
+* **Custom skill** (not Smart Home — see alternatives below), invocation name
+  `bedroom lights`. One intent `RunButtonIntent` with a custom slot type `ButtonName`
+  seeded with the current button names, plus the mandatory built-ins (Stop/Cancel/Help).
+  Utterances: "{buttonName}", "run {buttonName}", "set {buttonName}".
+* **Lambda in Go** (`aws-lambda-go`), keeping the repo single-language. An Alexa custom
+  skill is just JSON in/out over Lambda — no SDK needed for one intent; the handler is
+  ~100 lines: parse intent, extract slot, POST to brightlight with the bearer token and
+  pinned cert, speak back "OK, rainbow" or a friendly error.
+* **Configuration via Lambda environment variables**: `BRIGHTLIGHT_URL`,
+  `BRIGHTLIGHT_ALEXA_TOKEN` (Lambda env vars are encrypted at rest). Skill ID verification
+  in the handler so only our skill can invoke it.
+* Directory contents: `alexa/main.go` (handler), `alexa/skill.json` +
+  `alexa/interaction-model.json` (skill definition for the Alexa developer console),
+  `alexa/readme.md` (build/deploy steps: `GOOS=linux go build`, zip, upload).
+
+## Prerequisites (not code)
+
+* A stable way to reach home: DDNS hostname or static IP, and one router port-forward
+  (external 8443 → brightlight box 8443).
+* An Amazon developer account for the skill and an AWS account for the Lambda
+  (free tier covers this comfortably).
+
+## Alternatives considered
+
+1. **Smart Home skill (scenes)** — would allow the most natural phrasing
+   ("Alexa, turn on rainbow") by exposing each button as a scene, but *requires* OAuth2
+   account linking, device discovery responses, and the Smart Home API schema. Far more
+   moving parts for the same outcome. Custom skill phrasing costs us the word
+   "tell/ask": "Alexa, tell bedroom lights rainbow". Recommend custom skill for v1;
+   nothing in the brightlight endpoint would need to change if we upgraded later.
+2. **AWS IoT Core MQTT (outbound-only)** — brightlight connects *out* to AWS IoT over
+   mutual-TLS and subscribes to a command topic; Lambda publishes to it. No open ports,
+   no DDNS, survives IP changes. It is the more security-conservative design, but it
+   adds an MQTT client dependency, X.509 device certificates, and an always-on
+   connection to maintain (reconnect logic). More code and more AWS setup than option 1.
+   Worth switching to if opening a port is unacceptable.
+3. **Reusing `/RunAnimations/` directly** — rejected: it would mean exposing the existing
+   server (including config PUT, which writes files) to the internet, and Alexa knows
+   button *names*, not the full segment payload that endpoint requires.
+
+## Open questions to agree before coding
+
+1. Inbound HTTPS + port-forward (this plan) vs outbound MQTT (alternative 2)?
+2. Is `ui2/build/ui-config/user-buttons.json` the authoritative button set, or should the
+   old UI's `user.json` also be searched?
+3. Single room for now? If Titania/other rooms need their own skill later, we can add a
+   second invocation name pointing at the same Lambda with a different target URL, or a
+   room slot — but v1 assumes one brightlight instance.
+4. Lambda language: Go (proposed, single-language repo) vs Node/Python with the ASK SDK.
+5. Port number and where the token/cert files should live on the brightlight box.
+
+## Estimated size
+
+* `servers/alexa.go`: ~120 lines (auth middleware, file load, name match, two handlers)
+* `main.go`: ~10 lines (start TLS listener if token configured)
+* `alexa/main.go`: ~100 lines
+* Skill JSON + readmes: no runtime code

--- a/docs/alexa-integration-plan.md
+++ b/docs/alexa-integration-plan.md
@@ -89,6 +89,33 @@ writes, no file access, no UI exposure.
   `alexa/interaction-model.json` (skill definition for the Alexa developer console),
   `alexa/readme.md` (build/deploy steps: `GOOS=linux go build`, zip, upload).
 
+## Voice-to-button-name mapping
+
+Buttons are arbitrarily user-entered, so the mapping is done in two stages:
+
+**Stage 1 — Alexa speech → slot text.** The `ButtonName` custom slot's value list is
+training data, not a closed enum: Alexa biases recognition toward listed values but still
+returns its best-guess transcription for anything else. Keeping the list in sync:
+
+1. *Manual (v1)*: paste names into the developer console when buttons change;
+   `GET /alexa/Buttons` makes this a copy-paste job.
+2. *Dynamic entities (v2)*: Lambda fetches `/alexa/Buttons` at session start and injects
+   live names via `Dialog.UpdateDynamicEntities` (≤100 values) — recognition then tracks
+   button edits automatically; ~30 extra Lambda lines.
+3. *SMAPI model rebuilds*: overkill.
+
+**Stage 2 — slot text → button.** In `servers/alexa.go`:
+
+1. Normalise both sides: lowercase, trim, collapse whitespace, strip punctuation
+   ("sweet shop" ↔ "Sweet Shop", "off" ↔ "OFF").
+2. Exact match on normalised form.
+3. Fuzzy fallback for speech quirks: digit/word equivalence ("two" ↔ "2"), plus a small
+   prefix/edit-distance pass ("rainbows" → "Rainbow"). ~20 lines, no library.
+4. No match → 404; the Lambda speaks back what it heard so misrecognitions are audible.
+
+Caveat: unpronounceable names ("My 3", "BR2-Low") will always be unreliable — the fix is
+speakable button names, not code.
+
 ## Prerequisites (not code)
 
 * A stable way to reach home: DDNS hostname or static IP, and one router port-forward


### PR DESCRIPTION
Adds Alexa voice control of light settings by button name: **"Alexa, ask bedroom lights for rainbow"**.

## Brightlight server

- `backend/servers/alexa.go`: new opt-in HTTPS listener (default port 8443) with its own mux exposing only `POST /alexa/RunButton` and `GET /alexa/Buttons`. Not started unless `BRIGHTLIGHT_ALEXA_TOKEN` is set, so existing deployments are unaffected; the existing HTTP server stays LAN-only. Stdlib only (slog, net/http) — no new backend dependencies.
- Auth: bearer token with constant-time compare; bad tokens are logged and get 401.
- Buttons are read per request from `ui-config/user-buttons.json` (fallback `default-buttons.json`), so button edits are picked up immediately.
- Name matching: lowercase, punctuation stripped, number words mapped to digits ("two tone" ↔ "2 Tone"), exact match first, then an edit-distance fallback capped at 2 edits and a quarter of the name length (so "on" can never fuzzy-match "OFF").
- Unit tests in `backend/servers/alexa_test.go`.

## Alexa skill (`alexa/`)

- `interaction-model.json`: custom skill model, invocation "bedroom lights", one `RunButtonIntent` with a `ButtonName` slot seeded from the default buttons.
- `lambda/`: Go Lambda (own module, backend build untouched) that verifies the skill ID, forwards the spoken name with the bearer token over TLS pinned to the brightlight self-signed cert, and speaks back the matched button name or a friendly error.
- `readme.md`: cert/token generation, single router port-forward, Lambda packaging and skill setup steps.

## Design

`docs/alexa-integration-plan.md` records the agreed approach, alternatives considered (Smart Home skill, AWS IoT MQTT) and the voice-to-button-name mapping strategy.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./servers/` all pass (Go 1.26).
- Smoke-tested end-to-end after rebasing onto develop's backend/frontend restructure: ran the backend binary with a self-signed cert and token, exercised both endpoints over TLS with curl — good token lists buttons, bad token gets 401, "sweet shot" fuzzy-matches Sweet Shop, unknown names get 404.
- Not yet tested against a live Alexa device; utterances may need one round of tuning after deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdSSsDj4iktRN2rpvtF5ex