### PR TITLE
Review develop: fix remotely triggerable crashes, data races and API hardening

### DIFF
--- a/backend/animations/animate.go
+++ b/backend/animations/animate.go
@@ -216,6 +216,9 @@ func appendAnimatorsForAction(animators *[]segActionAndAnimator, seg SegmentActi
 		if err == nil {
 			brightness, err = seg.Params.asRange(2)
 		}
+		if err == nil && length < 1 {
+			err = errors.New("bad length parameter")
+		}
 		if err == nil {
 			*animators = append(*animators,
 				segActionAndAnimator{seg, newRepeater(
@@ -282,6 +285,9 @@ func appendAnimatorsForAction(animators *[]segActionAndAnimator, seg SegmentActi
 		var autoRepeat bool
 		if err == nil {
 			autoRepeat, err = seg.Params.asCheckbox(3)
+		}
+		if err == nil && duration < 1 {
+			err = errors.New("bad duration parameter")
 		}
 		if err == nil {
 			*animators = append(*animators, segActionAndAnimator{seg,
@@ -356,6 +362,17 @@ func resolveSegment(sa segActionAndAnimator, fb *framebuffer.FrameBuffer) (segme
 	return ns.GetSegment(fb), nil
 }
 
+// Animation parameters arrive over HTTP so a panicking animator must not
+// take down the whole server, drop its frame and keep rendering the rest
+func animateFrameSafely(a animator, frameCounter uint, seg segment.Segment) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Warn("animator panic recovered", "panic", r)
+		}
+	}()
+	a.animateFrame(frameCounter, seg)
+}
+
 // StartDriver Start animate driver
 func StartDriver(renderer chan *framebuffer.FrameBuffer) {
 	// Start the animator go routine
@@ -376,7 +393,7 @@ func StartDriver(renderer chan *framebuffer.FrameBuffer) {
 				for _, v := range animators {
 					// Resolve the segment to animate, based on string name
 					if seg, err := resolveSegment(v, fb); err == nil {
-						v.animator.animateFrame(frameCounter, seg)
+						animateFrameSafely(v.animator, frameCounter, seg)
 					}
 				}
 

--- a/backend/animations/life.go
+++ b/backend/animations/life.go
@@ -20,6 +20,10 @@ type life struct {
 
 func newLife(colour framebuffer.Rgb, framesPerGeneration uint, rule int, autoRepeat bool) *life {
 
+	// Guard against division by zero in animateFrame
+	if framesPerGeneration == 0 {
+		framesPerGeneration = 1
+	}
 	return &life{colour: colour, framesPerGeneration: framesPerGeneration, rule: rule, autoRepeat: autoRepeat}
 }
 

--- a/backend/animations/repeater.go
+++ b/backend/animations/repeater.go
@@ -20,6 +20,10 @@ func newRepeater(animator animator, repeatLength uint) *repeater {
 
 func (r *repeater) animateFrame(frameCount uint, frame segment.Segment) {
 
+	if r.repeatLength == 0 {
+		return
+	}
+
 	// Number of repeats and remaining pixels
 	repeat := frame.Len() / r.repeatLength
 	// TODO HOW TO HANDLE REMAINDER (SEPARATE CLASSES OR REMAINDER MODE)

--- a/backend/animations/runner.go
+++ b/backend/animations/runner.go
@@ -16,5 +16,8 @@ func newRunner(colour framebuffer.Rgb) *runner {
 
 func (r *runner) animateFrame(frameCount uint, frame segment.Segment) {
 
+	if frame.Len() == 0 {
+		return
+	}
 	frame.Set(frameCount%frame.Len(), r.colour)
 }

--- a/backend/animations/twinkle.go
+++ b/backend/animations/twinkle.go
@@ -28,8 +28,13 @@ func newTwinkle() *twinkle {
 }
 
 func randBetween(min int, max int) uint {
-	x := max - min
-	return uint(rand.Intn(x)) + uint(min)
+	if min < 0 {
+		min = 0
+	}
+	if max <= min {
+		return uint(min)
+	}
+	return uint(rand.Intn(max-min)) + uint(min)
 }
 
 // 8 bit saturation math subtraction
@@ -54,7 +59,7 @@ func (t *twinkle) animateFrame(frameCount uint, frame segment.Segment) {
 	}
 
 	// Adding heat every frame is too much so do it every 2 frames
-	if (frameCount % 2) == 0 {
+	if (frameCount%2) == 0 && len(t.pixies) > 0 {
 
 		// Add some heat to some random pixies
 		numPixiesToHeat := (len(t.pixies) * heatPercentage) / 100
@@ -62,7 +67,7 @@ func (t *twinkle) animateFrame(frameCount uint, frame segment.Segment) {
 			numPixiesToHeat = 1
 		}
 		for j := 0; j < numPixiesToHeat; j++ {
-			index := rand.Intn(len(t.pixies) - 1)
+			index := rand.Intn(len(t.pixies))
 			heat := uint8(randBetween(50, 255))
 			if heat > t.pixies[index] {
 				t.pixies[index] = heat

--- a/backend/controller/outputmapping.go
+++ b/backend/controller/outputmapping.go
@@ -1,9 +1,19 @@
 package controller
 
-import "github.com/andew42/brightlight/framebuffer"
+import (
+	"sync/atomic"
 
-var mappingEnabled = true
-var outputMappingTable = linear128
+	"github.com/andew42/brightlight/framebuffer"
+)
+
+// The current mapping table (nil when mapping is disabled), an atomic
+// pointer as it is set from HTTP handlers while teensy driver go routines
+// read it on every frame
+var outputMappingTable atomic.Pointer[[256]byte]
+
+func init() {
+	outputMappingTable.Store(&linear128)
+}
 
 var linear128 = [256]byte{
 	0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7,
@@ -66,27 +76,24 @@ func SetOutputMapping(mapping string) {
 
 	switch mapping {
 	case "Linear 128":
-		outputMappingTable = linear128
-		mappingEnabled = true
+		outputMappingTable.Store(&linear128)
 	case "Cie 128":
-		outputMappingTable = cie128
-		mappingEnabled = true
+		outputMappingTable.Store(&cie128)
 	case "Cie 256":
-		outputMappingTable = cie256
-		mappingEnabled = true
+		outputMappingTable.Store(&cie256)
 	default:
-		mappingEnabled = false
+		outputMappingTable.Store(nil)
 	}
 }
 
 func mapOutput(in framebuffer.Rgb) framebuffer.Rgb {
 
-	if !mappingEnabled {
+	table := outputMappingTable.Load()
+	if table == nil {
 		return in
-	} else {
-		return framebuffer.Rgb{
-			Red:   outputMappingTable[in.Red],
-			Green: outputMappingTable[in.Green],
-			Blue:  outputMappingTable[in.Blue]}
 	}
+	return framebuffer.Rgb{
+		Red:   table[in.Red],
+		Green: table[in.Green],
+		Blue:  table[in.Blue]}
 }

--- a/backend/controller/relay.go
+++ b/backend/controller/relay.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"errors"
 	"os"
+	"sync/atomic"
 	"time"
 
 	"log/slog"
@@ -28,10 +29,10 @@ func StartRelayDriver() {
 
 func IsRelayDriverConnected() bool {
 
-	return relayUsbConnected
+	return relayUsbConnected.Load()
 }
 
-var relayUsbConnected bool
+var relayUsbConnected atomic.Bool
 
 // Monitors changes to frame buffer and turns power supplies on or off via USB relay board
 func relayDriver() {
@@ -51,9 +52,9 @@ func relayDriver() {
 
 connectLoop:
 	for {
-		relayUsbConnected = false
+		relayUsbConnected.Store(false)
 		f := openUsbPortWithRetry(port)
-		relayUsbConnected = true
+		relayUsbConnected.Store(true)
 
 		// Initially we set all relays off
 		relayStates := [2]relayState{}
@@ -65,44 +66,45 @@ connectLoop:
 		// Request frame buffer updates
 		src, done := framebuffer.AddListener(port, false)
 
-		// Push frame buffer changes to Teensy
+		// Push frame buffer changes to the relay board
 	pushLoop:
 		for {
-			select {
-			case fb := <-src:
-				now := time.Now()
-				// foreach controller
-				controllerCount := len(fb.Strips) / config.StripsPerTeensy
-				for c := 0; c < controllerCount; c++ {
-					firstStripForController := c * config.StripsPerTeensy
-					// Should the controller's relay be off or on?
-					relayStates[c].requestState(
-						areAnyLedsOn(fb.Strips[firstStripForController:firstStripForController+config.StripsPerTeensy]),
-						now)
-				}
+			fb := <-src
+			now := time.Now()
+			// foreach controller
+			controllerCount := len(fb.Strips) / config.StripsPerTeensy
+			if controllerCount > len(relayStates) {
+				controllerCount = len(relayStates)
+			}
+			for c := 0; c < controllerCount; c++ {
+				firstStripForController := c * config.StripsPerTeensy
+				// Should the controller's relay be off or on?
+				relayStates[c].requestState(
+					areAnyLedsOn(fb.Strips[firstStripForController:firstStripForController+config.StripsPerTeensy]),
+					now)
+			}
 
-				// Work out the new actual states at this point in time
-				newRelayStates := [2]bool{}
-				updateRequired := false
-				for i := 0; i < len(newRelayStates); i++ {
-					updateRequired = relayStates[i].updateState(now) || updateRequired
-					newRelayStates[i] = relayStates[i].current
-				}
+			// Work out the new actual states at this point in time
+			newRelayStates := [2]bool{}
+			updateRequired := false
+			for i := 0; i < len(newRelayStates); i++ {
+				updateRequired = relayStates[i].updateState(now) || updateRequired
+				newRelayStates[i] = relayStates[i].current
+			}
 
-				// Update if changed
-				if updateRequired {
-					slog.Info("relayDriver update relays", "new states", newRelayStates)
-					if err := sendRelayState(f, newRelayStates); err != nil {
+			// Update if changed
+			if updateRequired {
+				slog.Info("relayDriver update relays", "new states", newRelayStates)
+				if err := sendRelayState(f, newRelayStates); err != nil {
 
-						slog.Warn("relayDriver failed to send relay command", "error", err.Error())
-						f.Close()
+					slog.Warn("relayDriver failed to send relay command", "error", err.Error())
+					f.Close()
 
-						// Close down listener
-						done <- src
+					// Close down listener
+					done <- src
 
-						// Try and reconnect
-						break pushLoop
-					}
+					// Try and reconnect
+					break pushLoop
 				}
 			}
 		}

--- a/backend/controller/teensy.go
+++ b/backend/controller/teensy.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"sync/atomic"
 	"time"
 
 	"log/slog"
@@ -26,13 +27,14 @@ func StartTeensyDriver() {
 	go teensyDriver(1)
 }
 
+// TeensyConnections Report connection state, atomics as the driver go
+// routines update the state concurrently with HTTP handlers reading it
 func TeensyConnections() []bool {
 
-	// TODO: 1 of 2 Returning here causes race detector to fail
-	return teensyConnections
+	return []bool{teensyConnections[0].Load(), teensyConnections[1].Load()}
 }
 
-var teensyConnections = make([]bool, 2)
+var teensyConnections [2]atomic.Bool
 
 // Monitors changes to frame buffer and update Teensy via USB
 func teensyDriver(driverIndex int) {
@@ -44,10 +46,9 @@ func teensyDriver(driverIndex int) {
 	}
 
 	for {
-		// TODO: 2 of 2 Writing here causes race detector to fail
-		teensyConnections[driverIndex] = false
+		teensyConnections[driverIndex].Store(false)
 		f := openUsbPortWithRetry(port)
-		teensyConnections[driverIndex] = true
+		teensyConnections[driverIndex].Store(true)
 
 		// Allocate buffer once to avoid garbage collections in loop
 		var data = make([]byte, 4+config.MaxLedStripLen*8*4+4)
@@ -56,64 +57,66 @@ func teensyDriver(driverIndex int) {
 		src, done := framebuffer.AddListener(port, true)
 
 		// Push frame buffer changes to Teensy
-	pushLoop:
 		for {
-			select {
-			case fb := <-src:
-				started := time.Now()
-				// Build the frame buffer, start with header of 4 * 0xff
-				i := 0
-				for z := 0; z < 4; z++ {
-					data[i] = 0xff
-					i++
-				}
-				startStrip := driverIndex * 8
-				var checksum int32 = 0
-				// Buffer is send 8*LED1, 8*LED2 ... 8*(LEDS_PER_STRIP - 1)
-				for l := 0; l < config.MaxLedStripLen; l++ {
-					for s := startStrip; s < startStrip+8; s++ {
-						if l >= len(fb.Strips[s].Leds) {
-							// Pad frame buffer with zeros as strip is < MaxLedStripLen
-							for z := 0; z < 4; z++ {
-								data[i] = 0
-								i++
-							}
-						} else {
-							// Perform the output mapping here
-							rgb := mapOutput(fb.Strips[s].Leds[l])
-							// Colours are sent as 4 bytes with leading 0x00
+			fb := <-src
+
+			// Skip if the frame buffer has no strips for this Teensy
+			// (e.g. a single Teensy configuration with a second port present)
+			startStrip := driverIndex * config.StripsPerTeensy
+			if startStrip+config.StripsPerTeensy > len(fb.Strips) {
+				continue
+			}
+
+			started := time.Now()
+			// Build the frame buffer, start with header of 4 * 0xff
+			i := 0
+			for z := 0; z < 4; z++ {
+				data[i] = 0xff
+				i++
+			}
+			var checksum int32 = 0
+			// Buffer is send 8*LED1, 8*LED2 ... 8*(LEDS_PER_STRIP - 1)
+			for l := 0; l < config.MaxLedStripLen; l++ {
+				for s := startStrip; s < startStrip+config.StripsPerTeensy; s++ {
+					if l >= len(fb.Strips[s].Leds) {
+						// Pad frame buffer with zeros as strip is < MaxLedStripLen
+						for z := 0; z < 4; z++ {
 							data[i] = 0
 							i++
-							data[i] = rgb.Red
-							i++
-							data[i] = rgb.Green
-							i++
-							data[i] = rgb.Blue
-							i++
-							// Update the checksum
-							checksum += (int32(rgb.Red) << 16) + (int32(rgb.Green) << 8) + int32(rgb.Blue)
 						}
+					} else {
+						// Perform the output mapping here
+						rgb := mapOutput(fb.Strips[s].Leds[l])
+						// Colours are sent as 4 bytes with leading 0x00
+						data[i] = 0
+						i++
+						data[i] = rgb.Red
+						i++
+						data[i] = rgb.Green
+						i++
+						data[i] = rgb.Blue
+						i++
+						// Update the checksum
+						checksum += (int32(rgb.Red) << 16) + (int32(rgb.Green) << 8) + int32(rgb.Blue)
 					}
 				}
-
-				// Append checksum MSB first
-				for z := 3; z >= 0; z-- {
-					data[i] = byte((checksum >> (8 * uint(z))) & 0xff)
-					i++
-				}
-
-				if _, err := f.Write(data); err != nil {
-					slog.Warn("teensyDriver send failed", "error", err.Error())
-					f.Close()
-
-					// Close down listener
-					done <- src
-
-					// Try and reconnect
-					break pushLoop
-				}
-				stats.AddSerialSendTimeSample(port, time.Since(started))
 			}
+
+			// Append checksum MSB first
+			for z := 3; z >= 0; z-- {
+				data[i] = byte((checksum >> (8 * uint(z))) & 0xff)
+				i++
+			}
+
+			if _, err := f.Write(data); err != nil {
+				slog.Warn("teensyDriver send failed", "error", err.Error())
+				f.Close()
+
+				// Close down listener then try and reconnect
+				done <- src
+				break
+			}
+			stats.AddSerialSendTimeSample(port, time.Since(started))
 		}
 	}
 }

--- a/backend/segment/namedsegment.go
+++ b/backend/segment/namedsegment.go
@@ -21,6 +21,17 @@ type NamedSegment struct {
 	GetSegment func(fb *framebuffer.FrameBuffer) Segment
 }
 
+// Strip lengths of the static frame buffer layout, used to validate pXX:YY
+// segment requests up front rather than panicking in the animation driver
+var stripLengths = func() []uint {
+	fb := framebuffer.NewFrameBuffer()
+	lengths := make([]uint, len(fb.Strips))
+	for i := range fb.Strips {
+		lengths[i] = uint(len(fb.Strips[i].Leds))
+	}
+	return lengths
+}()
+
 // GetNamedSegment Return a particular named segment
 func GetNamedSegment(name string) (NamedSegment, error) {
 
@@ -30,6 +41,12 @@ func GetNamedSegment(name string) (NamedSegment, error) {
 		colonIndex := strings.IndexByte(name, ':')
 		if stripIndex, err := strconv.Atoi(name[1:colonIndex]); err == nil {
 			if length, err := strconv.Atoi(name[colonIndex+1:]); err == nil {
+				// The name arrives from the HTTP API so a bad strip index or
+				// length must be rejected, not trusted
+				if stripIndex < 0 || stripIndex >= len(stripLengths) ||
+					length < 0 || uint(length) > stripLengths[stripIndex] {
+					return NamedSegment{}, errors.New("Segment '" + name + "' out of range")
+				}
 				return NamedSegment{
 					Name: name,
 					GetSegment: func(fb *framebuffer.FrameBuffer) Segment {

--- a/backend/segment/namedsegment_test.go
+++ b/backend/segment/namedsegment_test.go
@@ -1,0 +1,45 @@
+package segment
+
+import (
+	"testing"
+
+	"github.com/andew42/brightlight/framebuffer"
+)
+
+// Physical pXX:YY segment names arrive from the HTTP API so out of range
+// values must return an error rather than panicking the animation driver
+func TestGetNamedSegmentPhysicalBounds(t *testing.T) {
+
+	// A valid strip index and length
+	if _, err := GetNamedSegment("p0:10"); err != nil {
+		t.Errorf("GetNamedSegment(p0:10) unexpected error: %v", err)
+	}
+
+	// Out of range indexes and lengths must be rejected
+	for _, name := range []string{"p99:10", "p-1:5", "p0:99999", "p0:-1"} {
+		if _, err := GetNamedSegment(name); err == nil {
+			t.Errorf("GetNamedSegment(%q) expected an error", name)
+		}
+	}
+}
+
+// A zero length request (including on an unused zero length strip) is valid
+// and must resolve to an empty segment without panicking
+func TestGetNamedSegmentZeroLength(t *testing.T) {
+
+	fb := framebuffer.NewFrameBuffer()
+	for i := range fb.Strips {
+		name := "p" + string(rune('0'+i%10)) + ":0"
+		if i > 9 {
+			continue // single digit indexes are enough for this test
+		}
+		ns, err := GetNamedSegment(name)
+		if err != nil {
+			t.Errorf("GetNamedSegment(%q) unexpected error: %v", name, err)
+			continue
+		}
+		if got := ns.GetSegment(fb).Len(); got != 0 {
+			t.Errorf("GetNamedSegment(%q).Len() = %d, want 0", name, got)
+		}
+	}
+}

--- a/backend/segment/subsegment.go
+++ b/backend/segment/subsegment.go
@@ -15,14 +15,11 @@ type SubSegment struct {
 // NewSubSegment A sub-segment is a slice of another segment
 func NewSubSegment(baseSeg Segment, start uint, len uint) SubSegment {
 
-	baseLen := baseSeg.Len()
-	if start >= baseLen {
-		slog.Error("invalid segment start")
-		panic("invalid segment start")
-	}
-	if start+len > baseLen {
-		slog.Error("invalid segment length")
-		panic("invalid segment length")
+	// A zero length sub-segment is valid (nothing to light) so only the
+	// combination of start and length must fit within the base segment
+	if start+len > baseSeg.Len() {
+		slog.Error("invalid segment start or length")
+		panic("invalid segment start or length")
 	}
 	return SubSegment{baseSeg, start, len}
 }

--- a/backend/servers/buttonstate.go
+++ b/backend/servers/buttonstate.go
@@ -27,10 +27,11 @@ func updateActiveButtonKey(key int) {
 	})
 }
 
-// Called by config server to update button pad save version
-func updateButtonPadVersion(ver int) {
+// Called by config server when the button pad has been saved, the mutex
+// makes the increment safe when several saves arrive concurrently
+func incrementButtonPadVersion() {
 	updateCurrentButtonState(func() {
-		currentButtonState.ButtonPadVersion = ver
+		currentButtonState.ButtonPadVersion++
 	})
 }
 

--- a/backend/servers/buttonstate_test.go
+++ b/backend/servers/buttonstate_test.go
@@ -29,7 +29,7 @@ func TestButtonStateBroadcastDoesNotBlock(t *testing.T) {
 				listenersMux.Unlock()
 
 				updateActiveButtonKey(i)
-				updateButtonPadVersion(i)
+				incrementButtonPadVersion()
 
 				// Remove without draining, racing with other broadcasts
 				removeButtonListener(c)

--- a/backend/servers/config.go
+++ b/backend/servers/config.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 )
 
-var configVersion = 0
-
 // GetConfigHandler Handle HTTP requests to read and write ui-config files.
 // uiConfigDir is the filesystem path to the ui-config directory.
 func GetConfigHandler(uiConfigDir string) func(http.ResponseWriter, *http.Request) {
@@ -46,10 +44,10 @@ func GetConfigHandler(uiConfigDir string) func(http.ResponseWriter, *http.Reques
 
 			slog.Info("configHandler PUT called", "FullPath", fullPath)
 
-			// Only support writing user.json (ui) and user-buttons.json (ui2)
+			// Only support writing user-buttons.json
 			if r.URL.Path != "/api/ui-config/user-buttons.json" {
 				slog.Warn("Unsupported config file name", "FileName", r.URL.Path)
-				http.Error(w, "File name not allowed", 401)
+				http.Error(w, "File name not allowed", 403)
 				return
 			}
 
@@ -64,8 +62,7 @@ func GetConfigHandler(uiConfigDir string) func(http.ResponseWriter, *http.Reques
 					http.Error(w, "Failed to write file", 507)
 				} else {
 					// Let clients know the config has been updated
-					configVersion++
-					updateButtonPadVersion(configVersion)
+					incrementButtonPadVersion()
 				}
 			}
 		} else {

--- a/backend/servers/option.go
+++ b/backend/servers/option.go
@@ -19,7 +19,7 @@ func OptionHandler(w http.ResponseWriter, r *http.Request) {
 
 	// JSON body of form
 	// {"cmd": "outputMapping", "param": "Linear"},
-	body, err := io.ReadAll(r.Body)
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 4096))
 	if err != nil {
 		slog.Error("OptionHandler bad body", "err", err.Error())
 		http.Error(w, err.Error(), 400)

--- a/backend/servers/runanimations.go
+++ b/backend/servers/runanimations.go
@@ -31,7 +31,7 @@ func RunAnimationsHandler(w http.ResponseWriter, r *http.Request) {
 	//   ]
 	// },
 
-	body, err := io.ReadAll(r.Body)
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 65536))
 	if err != nil {
 		slog.Error("RunAnimationsHandler bad body", "err", err.Error())
 		http.Error(w, err.Error(), 400)

--- a/backend/servers/striplength.go
+++ b/backend/servers/striplength.go
@@ -21,8 +21,14 @@ func StripLenHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// index
 	configStrings := strings.Split(r.URL.Path[extIndex+1:], ",")
+	if len(configStrings) != 2 {
+		http.Error(w, "Expected index,length parameters", 406)
+		slog.Info("stripLengthHandler called with wrong parameter count")
+		return
+	}
+
+	// index
 	index, err := strconv.ParseInt(configStrings[0], 10, 32)
 	if err != nil {
 		index = -1


### PR DESCRIPTION
Code review of `develop` focused on bugs and security issues, with a few simplifications. All changes are backend-only; frontend and Alexa lambda reviewed with no changes needed.

## Crash fixes — each of these killed the whole server with one HTTP request

The animation driver runs in a plain goroutine, so any panic there terminates the process (unlike handler panics, which `net/http` recovers). Several user-supplied values reached it unvalidated:

- **Unvalidated `pXX:YY` physical segment names** (`segment/namedsegment.go`): `POST /api/RunAnimations/` with a segment named e.g. `p0:99999` or `p99:10` sliced `fb.Strips` out of range or tripped the `NewSubSegment` panic. Strip index and length are now validated against the static strip layout and rejected with an error.
- **Zero-length strips** (`segment/subsegment.go`): `POST /api/StripLength/3,0` on a zero-length (unused) strip panicked in `NewSubSegment` (`start >= baseLen` with `0 >= 0`). Zero-length sub-segments are now representable; only `start+len > baseLen` is rejected.
- **Division by zero in animators** reachable from JSON parameters: `Life` with duration 0, `Baby Bows` with length 0 (repeater), `Runner` on an empty user segment. `Baby Bows` now validates length like `Discrete` already did; `life`, `repeater` and `runner` also guard internally.
- **`rand.Intn` panics**: `twinkle` on a 0- or 1-LED segment, and `Sweet Shop` with min saturation ≥ 100 via `randBetween`. While there, `rand.Intn(len-1)` also never heated the last twinkle pixel.
- **`StripLength` handler** panicked on `configStrings[1]` when the path had no comma (`POST /api/StripLength/5`); now returns 406.
- **Defence in depth**: the render loop wraps each animator in a `recover`, so any residual panic drops one segment's frame instead of terminating the server.

Verified end-to-end: ran the server and replayed every vector above — all return normal error responses and the server keeps serving.

## Data race fixes

- `teensyConnections` — the two `// TODO: causes race detector to fail` comments in `controller/teensy.go`; now `atomic.Bool`s (written by driver goroutines, read by `/api/RunAnimations/`). Same for `relayUsbConnected`.
- Output mapping table (`controller/outputmapping.go`) was swapped by the `/api/option/` handler while both Teensy drivers read it every frame; now an `atomic.Pointer` (nil = mapping disabled), which also removes the separate `mappingEnabled` flag.
- `configVersion++` in the config PUT handler was unsynchronised across concurrent requests; the version is now incremented under `listenersMux` inside `buttonstate.go`, removing the extra global.

## Hardening

- Body size limits on `/api/RunAnimations/` (64K) and `/api/option/` (4K), matching the existing limit on config PUT.
- `403` instead of `401` for disallowed ui-config file names (it's an authorisation-style rejection, and 401 without `WWW-Authenticate` is non-conformant).
- The Teensy driver now skips frames when the frame buffer has no strips for its index: with the 8-strip Titania config, a device appearing on the second port (`/dev/ttyACM1`) would have indexed `fb.Strips[8..15]` and crashed.

## Simplifications

- Single-case `select` statements in the Teensy and relay push loops replaced with plain channel receives, dropping the `pushLoop` label in the Teensy driver.
- Literal `8` in the Teensy driver replaced with `config.StripsPerTeensy`.
- Folding `configVersion` into the existing button state (above) removes a global and a code path.

## Tests

- New `segment/namedsegment_test.go` regression tests for `pXX:YY` bounds validation and zero-length resolution.
- `go build ./...`, `go vet ./...`, `go test -race ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmYA6MSPnUxpz7i3VN5apf

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmYA6MSPnUxpz7i3VN5apf)_