### PR TITLE
Add dead area below button pad to avoid iOS swipe-up home gesture

### DIFF
--- a/frontend/src/buttons/ButtonPad.css
+++ b/frontend/src/buttons/ButtonPad.css
@@ -10,6 +10,10 @@
     grid-column-gap: 6px;
     grid-row-gap: 6px;
     padding: 6px;
+    /* Dead area below the bottom button row so the iOS swipe-up home
+       gesture doesn't trigger a button (.App's safe-area-inset-bottom
+       alone isn't enough — the swipe registers a touch above it) */
+    padding-bottom: 38px;
     background-color: purple;
 }
 


### PR DESCRIPTION
The bottom row of buttons extends close enough to the screen edge that
the iOS swipe-up-to-home gesture registers a tap on the middle bottom
button, changing the light setting. The .App safe-area inset alone is
not enough, so add fixed bottom padding to the button pad grid.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ce6d8Ufs6478yEqWsKUEkU