### PR TITLE
Add Lava Lamp animation with organic drifting colour blobs

### DIFF
--- a/backend/animations/animate.go
+++ b/backend/animations/animate.go
@@ -205,6 +205,31 @@ func appendAnimatorsForAction(animators *[]segActionAndAnimator, seg SegmentActi
 			slog.Warn("Bad animation parameter", "params", seg.Params, "error", err.Error())
 		}
 
+	case "Lava Lamp":
+		var err error
+		blobColour, err := seg.Params.asColour(0)
+		var background framebuffer.Rgb
+		if err == nil {
+			background, err = seg.Params.asColour(1)
+		}
+		var speed int
+		if err == nil {
+			speed, err = seg.Params.asRange(2)
+		}
+		var blobCount int
+		if err == nil {
+			blobCount, err = seg.Params.asRange(3)
+		}
+		if err == nil && (speed < 1 || blobCount < 1) {
+			err = errors.New("bad speed or blob count parameters")
+		}
+		if err == nil {
+			*animators = append(*animators,
+				segActionAndAnimator{seg, newLava(blobColour, background, speed, blobCount)})
+		} else {
+			slog.Warn("Bad animation parameter", "params", seg.Params, "error", err.Error())
+		}
+
 	case "Baby Bows":
 		var err error
 		length, err := seg.Params.asRange(0)

--- a/backend/animations/lava.go
+++ b/backend/animations/lava.go
@@ -1,0 +1,121 @@
+package animations
+
+import (
+	"math"
+	"math/rand"
+
+	"github.com/andew42/brightlight/framebuffer"
+	"github.com/andew42/brightlight/segment"
+)
+
+// Lava lamp effect: distinct blobs of one colour drift slowly through a
+// background colour, merging and separating like wax in a lava lamp.
+// Each blob's position and size are driven by summed sine waves with
+// randomised frequencies and phases. The blobs contribute to a
+// metaball-style field which is soft-thresholded so blob interiors are
+// solid colour with rounded edges that blend into the background.
+
+type lavaBlob struct {
+	// Drift frequencies and phases (primary slow drift + faster wobble)
+	w1, p1 float64
+	w2, p2 float64
+	// Size breathing frequency and phase
+	w3, p3 float64
+	// Relative size multiplier
+	size float64
+}
+
+type lava struct {
+	blobColour float64Rgb
+	background float64Rgb
+	speed      float64
+	radius     float64
+	blobs      []lavaBlob
+}
+
+// Rgb as floats to avoid per-pixel byte conversions while blending
+type float64Rgb struct {
+	r, g, b float64
+}
+
+func toFloat64Rgb(c framebuffer.Rgb) float64Rgb {
+	return float64Rgb{float64(c.Red), float64(c.Green), float64(c.Blue)}
+}
+
+func newLava(blobColour framebuffer.Rgb, background framebuffer.Rgb, speed int, blobCount int) *lava {
+
+	blobs := make([]lavaBlob, blobCount)
+	for i := range blobs {
+		blobs[i] = lavaBlob{
+			w1:   0.6 + rand.Float64()*0.8,
+			p1:   rand.Float64() * 2 * math.Pi,
+			w2:   1.3 + rand.Float64()*1.4,
+			p2:   rand.Float64() * 2 * math.Pi,
+			w3:   0.9 + rand.Float64()*1.1,
+			p3:   rand.Float64() * 2 * math.Pi,
+			size: 0.7 + rand.Float64()*0.6,
+		}
+	}
+
+	return &lava{
+		blobColour: toFloat64Rgb(blobColour),
+		background: toFloat64Rgb(background),
+		// speed 1..10 scaled so mid values take tens of seconds per drift cycle
+		speed: float64(speed) * 0.2,
+		// Base blob radius as a fraction of the segment, smaller with more blobs
+		radius: 0.5 / float64(blobCount),
+		blobs:  blobs,
+	}
+}
+
+func smoothstep(edge0 float64, edge1 float64, x float64) float64 {
+	t := (x - edge0) / (edge1 - edge0)
+	if t < 0 {
+		t = 0
+	} else if t > 1 {
+		t = 1
+	}
+	return t * t * (3 - 2*t)
+}
+
+// animation interface
+func (l *lava) animateFrame(frameCount uint, frame segment.Segment) {
+
+	if frame.Len() == 0 {
+		return
+	}
+
+	// Frame period is 40ms so t advances 0.04 * speed per real second
+	t := float64(frameCount) * 0.04 * l.speed
+
+	// Precompute each blob's position and radius for this frame
+	positions := make([]float64, len(l.blobs))
+	radii := make([]float64, len(l.blobs))
+	for k, b := range l.blobs {
+		// Slow primary drift plus a faster low amplitude wobble,
+		// amplitudes sum to <0.5 so blobs stay within the segment
+		positions[k] = 0.5 + 0.36*math.Sin(b.w1*t+b.p1) + 0.14*math.Sin(b.w2*t+b.p2)
+		// Radius breathes around its base size
+		radii[k] = l.radius * b.size * (1 + 0.25*math.Sin(b.w3*t+b.p3))
+	}
+
+	for i := uint(0); i < frame.Len(); i++ {
+		pos := float64(i) / float64(frame.Len())
+
+		// Metaball field: gaussian contribution from each blob so
+		// nearby blobs merge smoothly into a single larger blob
+		field := 0.0
+		for k := range l.blobs {
+			d := (pos - positions[k]) / radii[k]
+			field += math.Exp(-d * d * 3.0)
+		}
+
+		// Soft threshold: solid blob interior, rounded blended edge
+		a := smoothstep(0.15, 0.75, field)
+
+		frame.Set(i, framebuffer.NewRgb(
+			byte(l.background.r+(l.blobColour.r-l.background.r)*a),
+			byte(l.background.g+(l.blobColour.g-l.background.g)*a),
+			byte(l.background.b+(l.blobColour.b-l.background.b)*a)))
+	}
+}

--- a/backend/ui-config/default-buttons.json
+++ b/backend/ui-config/default-buttons.json
@@ -145,16 +145,17 @@
     },
     {
       "key": 11,
-      "name": "Plasma Lava Lamp",
+      "name": "Lava Lamp",
       "segments": [
         {
           "name": "All",
           "z": 1,
-          "animation": "Plasma",
+          "animation": "Lava Lamp",
           "params": [
-            {"key": 110, "type": "range", "label": "Speed", "min": 1, "max": 100, "value": 50},
-            {"key": 111, "type": "range", "label": "Brightness", "min": 10, "max": 60, "value": 50},
-            {"key": 112, "type": "range", "label": "Palette", "min": 0, "max": 3, "value": 0}
+            {"key": 140, "type": "colour", "label": "Blob Colour", "value": {"r": 255, "g": 16, "b": 0}},
+            {"key": 141, "type": "colour", "label": "Background", "value": {"r": 48, "g": 0, "b": 64}},
+            {"key": 142, "type": "range", "label": "Speed", "min": 1, "max": 10, "value": 3},
+            {"key": 143, "type": "range", "label": "Blobs", "min": 1, "max": 12, "value": 5}
           ]
         }
       ]

--- a/backend/ui-config/static-data-bedroom.json
+++ b/backend/ui-config/static-data-bedroom.json
@@ -37,6 +37,12 @@
       {"key":131, "type":"range", "label":"Brightness", "min":10, "max":50, "value":40},
       {"key":132, "type":"range", "label":"Palette(0-3)", "min":0, "max":3, "value":1}
     ]},
+    {"name":"Lava Lamp", "params":[
+      {"key":140, "type":"colour", "label":"Blob Colour", "value":{"r":255, "g":16, "b":0}},
+      {"key":141, "type":"colour", "label":"Background", "value":{"r":48, "g":0, "b":64}},
+      {"key":142, "type":"range", "label":"Speed", "min":1, "max":10, "value":3},
+      {"key":143, "type":"range", "label":"Blobs", "min":1, "max":12, "value":5}
+    ]},
     {"name":"Life", "params":[
       {"key":120, "type":"colour", "label":"Colour", "value":{"r":128, "g":128, "b":128}},
       {"key":121, "type":"range", "label":"Duration(frames)", "min":1, "max":100, "value":25},

--- a/backend/ui-config/static-data.json
+++ b/backend/ui-config/static-data.json
@@ -60,6 +60,14 @@
     ]
     },
     {
+      "name": "Lava Lamp", "params": [
+      {"key": 140, "type": "colour", "label": "Blob Colour", "value": {"r": 255, "g": 16, "b": 0}},
+      {"key": 141, "type": "colour", "label": "Background", "value": {"r": 48, "g": 0, "b": 64}},
+      {"key": 142, "type": "range", "label": "Speed", "min": 1, "max": 10, "value": 3},
+      {"key": 143, "type": "range", "label": "Blobs", "min": 1, "max": 12, "value": 5}
+    ]
+    },
+    {
       "name": "Life", "params": [
       {"key": 120, "type": "colour", "label": "Colour", "value": {"r": 128, "g": 128, "b": 128}},
       {"key": 121, "type": "range", "label": "Duration(frames)", "min": 1, "max": 100, "value": 25},


### PR DESCRIPTION
Distinct blobs of a configurable colour (default red) drift through a
background colour (default purple), merging and separating like wax in
a lava lamp. Blob positions and sizes are driven by summed sine waves
with randomised frequencies and phases; a soft-thresholded metaball
field keeps blob interiors solid with rounded organic edges.

Parameters: blob colour, background colour, speed (1-10) and blob
count (1-12). Added to both site static-data files and the default
button pad (replacing the Plasma-based Lava Lamp button).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YXWVFhRcgojDZMTGWciWLq