### PR TITLE
Update docs and build scripts to match current codebase and CI pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,12 +5,15 @@
 A domestic LED lighting controller. A Go web server runs on a Raspberry Pi and
 drives WS2811 pixel-addressable LED strips via a Teensy 3.x microcontroller
 connected over USB serial. A React web app (served by the Go server) lets the
-user choose and configure lighting animations.
+user choose and configure lighting animations. An optional Alexa custom skill
+(AWS Lambda) provides voice control of the configured buttons.
 
 ## Repository layout
 
 ```
 brightlight/
+├── .github/workflows/
+│   └── build.yml      CI: backend + frontend builds, Pi bundle, rolling release
 ├── frontend/          React web app (Vite + React 19)
 │   ├── src/           JSX source — all files use .jsx extension
 │   ├── public/        Static assets (icons, manifest, segment-icons)
@@ -21,17 +24,22 @@ brightlight/
 ├── backend/           Go server
 │   ├── main.go        Entry point; serves frontend/build/ as static files
 │   ├── go.mod         module github.com/andew42/brightlight, Go 1.26
-│   ├── animations/    LED animation effects (14 animations)
+│   ├── animations/    LED animation effects (rainbow, plasma, twinkle, …)
 │   ├── config/        Network config, presets, static data
 │   ├── controller/    Teensy USB serial driver + relay driver
 │   ├── framebuffer/   In-memory LED frame buffer
 │   ├── segment/       Named/physical/combined LED segment abstractions
-│   ├── servers/       HTTP handlers (animations, config, SSE streams)
+│   ├── servers/       HTTP handlers (animations, config, SSE streams, Alexa)
 │   ├── stats/         Performance statistics
 │   └── ui-config/     Button/segment config JSON (served via /api/ui-config)
+├── alexa/             Alexa voice control (see alexa/readme.md)
+│   ├── interaction-model.json  Custom skill interaction model
+│   └── lambda/        AWS Lambda (Go module, aws-lambda-go) calling the server
 ├── firmware/          Arduino/Teensy C firmware (OctoWS2811)
+├── packaging/         Pi install: systemd unit + install.sh (bundled by CI)
 ├── deploy/            Staging area for Pi deployment artefacts (generated)
 │   └── README.md      How to build and deploy
+├── docs/              Design notes (Alexa integration plan)
 ├── full-build.sh      Linux/macOS build script: frontend + backend → deploy/
 ├── full-build.bat     Windows equivalent
 ├── readme.md          Original project README with Pi setup instructions
@@ -44,8 +52,10 @@ brightlight/
 |-------|-----------|
 | Frontend | React 19, React Router 7, Vite 8 (semantic-ui removed) |
 | Backend | Go 1.26, stdlib only (log/slog, net/http with SSE) — zero external deps |
-| Hardware | Raspberry Pi (Linux ARM), Teensy 3.x, WS2811 LED strips |
-| Build | Vite (frontend), cross-compiled Go GOARCH=arm GOARM=5 (backend) |
+| Hardware | Raspberry Pi 2B (Linux ARMv7), Teensy 3.x, WS2811 LED strips |
+| Voice | Alexa custom skill → AWS Lambda (separate Go module, aws-lambda-go) |
+| Build | Vite (frontend), cross-compiled Go GOOS=linux GOARCH=arm GOARM=7 (backend) |
+| CI/CD | GitHub Actions (`.github/workflows/build.yml`) → rolling `latest` GitHub release |
 
 ## Runtime configuration
 
@@ -57,24 +67,40 @@ the UI requests the generic names. On a Pi it is set via a systemd drop-in
 written by `packaging/install.sh --site <site>`.
 
 The Go binary uses `BRIGHTLIGHT` env var as the base path for static files.
-With `BRIGHTLIGHT=/home/pi` it looks for:
-- Frontend: `/home/pi/frontend/build/` (index.html, assets/)
-- Button config: `/home/pi/backend/ui-config/`
+The Pi installer sets `BRIGHTLIGHT=/opt/brightlight` (in the systemd unit),
+under which it looks for:
+- Frontend: `/opt/brightlight/frontend/build/` (index.html, assets/)
+- Button config: `/opt/brightlight/backend/ui-config/`
 
 When `BRIGHTLIGHT` is unset (development) static content is not served — use
 the Vite dev server, which proxies `/api` to `http://localhost:8080` — and
 button config is read from `ui-config/` relative to the working directory.
 
-## How to build locally (development)
+The Alexa endpoint is opt-in via env vars (see `alexa/readme.md`): it starts
+only when `BRIGHTLIGHT_ALEXA_TOKEN` is set, needs `BRIGHTLIGHT_ALEXA_CERT` /
+`BRIGHTLIGHT_ALEXA_KEY` (TLS cert/key paths), and listens on its own HTTPS
+port (`BRIGHTLIGHT_ALEXA_PORT`, default 8443).
+
+## How to build
 
 ```bash
 # Frontend dev server (proxies /api to backend at localhost:8080)
 cd frontend && npm start
 
-# Build for deployment — outputs to deploy/
+# Backend dev server
+cd backend && go run .
+
+# Build for deployment — outputs to deploy/ (same steps/layout as CI)
 full-build.sh    # Linux/macOS
 full-build.bat   # Windows
 ```
+
+CI (`.github/workflows/build.yml`) runs on every push/PR to `master` or
+`develop`: it vets and cross-compiles the backend for Raspberry Pi 2B
+(GOARM=7), builds the frontend with Vite (`npm ci && npm run build`), then on
+push assembles `brightlight-pi.tar.gz` (binary, frontend build, ui-config,
+systemd unit, installer) and republishes it as the rolling `latest` GitHub
+release. A Pi installs/upgrades with one command — see `deploy/README.md`.
 
 ## HTTP API (backend → frontend contract)
 
@@ -90,6 +116,14 @@ All API routes are under `/api`. The push channels use Server-Sent Events
 | `/api/FrameBuffer` | SSE | Push raw LED frame data (virtual display) |
 | `/api/Stats` | SSE | Push performance stats |
 | `/api/option/` | POST | Set server options |
+
+The Alexa endpoints live on a separate opt-in HTTPS listener (default port
+8443, bearer-token auth — see `backend/servers/alexa.go`):
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/alexa/RunButton` | POST | Run a button by spoken name (`{"button":"rainbow"}`) |
+| `/alexa/Buttons` | GET | List button names (for skill slot values) |
 
 ## Key gotchas and past decisions
 
@@ -131,3 +165,22 @@ The `/ui/` HTTP route and `/config/` handler have been removed from `main.go`.
 Reorganised from flat layout into `frontend/`, `backend/`, `deploy/` to allow
 opening each part as a separate IntelliJ project. Previously `ui2/` was the
 frontend and all Go files lived at the repo root.
+
+### Alexa voice control (July 2026)
+Voice control goes Alexa → custom skill → AWS Lambda (`alexa/lambda/`, its own
+Go module with the repo's only external dep, `aws-lambda-go`) → HTTPS + bearer
+token + pinned self-signed cert → `/alexa/RunButton` on the brightlight box.
+The backend module itself remains stdlib-only. Spoken names are fuzzy-matched
+against button names in `user-buttons.json` (fallback `default-buttons.json`).
+The listener is disabled unless `BRIGHTLIGHT_ALEXA_TOKEN` is set. Setup steps
+in `alexa/readme.md`; design discussion in `docs/alexa-integration-plan.md`.
+
+### CI pipeline and one-command Pi install (July 2026)
+`.github/workflows/build.yml` builds backend (ARMv7, GOARM=7 — the target is a
+Pi 2B; the old scripts used GOARM=5) and frontend, then packages a Pi bundle
+and republishes it as the rolling `latest` GitHub release on every push to
+`master`/`develop`. A Pi installs or upgrades with
+`curl -fsSL .../releases/latest/download/install.sh | sudo bash`, which
+installs to `/opt/brightlight` and sets up a systemd service (`packaging/`),
+replacing the old manual scp + `/etc/rc.local` flow. `full-build.sh`/`.bat`
+mirror the CI build steps for a local build staged into `deploy/`.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -40,17 +40,21 @@ The web UI is served on port 8080. The installer sources live in
 
 ## Manual build (this directory)
 
-This directory is the staging area for locally built artefacts.
+This directory is the staging area for locally built artefacts. Its layout
+matches the CI Pi bundle:
 
 | Path | Source | Description |
 |------|--------|-------------|
-| `brightlight` | `backend/` Go build | Linux ARM binary |
+| `brightlight` | `backend/` Go build | Linux ARMv7 binary (GOARM=7) |
 | `frontend/build/` | `frontend/` Vite build | React app static files |
 | `backend/ui-config/` | `backend/ui-config/` | Button/segment config JSON |
+| `brightlight.service` | `packaging/` | systemd unit |
+| `install.sh` | `packaging/` | Pi installer script |
 
 Run `full-build.sh` (Linux/macOS) or `full-build.bat` (Windows) from the repo
-root to populate it, then copy the three entries above to the Pi. With
-`BRIGHTLIGHT=<base>` the server expects:
+root to populate it — the scripts run the same steps as CI (`npm ci` +
+Vite build, `go vet`, ARMv7 cross-compile) — then copy the entries above to
+the Pi. With `BRIGHTLIGHT=<base>` the server expects:
 
 - Binary anywhere (conventionally `<base>/brightlight`)
 - Frontend at `<base>/frontend/build/`

--- a/full-build.bat
+++ b/full-build.bat
@@ -1,15 +1,27 @@
 @echo off
+rem Local equivalent of the CI pipeline (.github/workflows/build.yml):
+rem builds the frontend and backend the same way and stages the artefacts
+rem in deploy\ with the same layout as the CI Pi bundle.
+
 echo Building frontend...
 cd frontend
+call npm ci
+if errorlevel 1 exit /b 1
 call npm run build
+if errorlevel 1 exit /b 1
 cd ..
 
-echo Building backend for Linux ARM (Raspberry Pi)...
+echo Vetting backend...
 cd backend
+go vet ./...
+if errorlevel 1 exit /b 1
+
+echo Building backend for Raspberry Pi 2B (linux/arm v7)...
 set GOOS=linux
 set GOARCH=arm
-set GOARM=5
-go build -o ../deploy/brightlight
+set GOARM=7
+go build -o ../deploy/brightlight .
+if errorlevel 1 exit /b 1
 set GOOS=
 set GOARCH=
 set GOARM=
@@ -21,4 +33,8 @@ robocopy frontend\build deploy\frontend\build /MIR /NFL /NDL /NJH /NJS /NC /NS /
 echo Copying ui-config to deploy...
 robocopy backend\ui-config deploy\backend\ui-config /MIR /NFL /NDL /NJH /NJS /NC /NS /NP
 
-echo Done. Deploy directory is ready for scp to Pi.
+echo Copying systemd unit and installer to deploy...
+copy /Y packaging\brightlight.service deploy\ >nul
+copy /Y packaging\install.sh deploy\ >nul
+
+echo Done. Deploy directory matches the CI bundle layout, ready for scp to Pi.

--- a/full-build.sh
+++ b/full-build.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
+# Local equivalent of the CI pipeline (.github/workflows/build.yml):
+# builds the frontend and backend the same way and stages the artefacts
+# in deploy/ with the same layout as the CI Pi bundle.
 set -e
 
 echo "Building frontend..."
 cd frontend
+npm ci
 npm run build
 cd ..
 
-echo "Building backend for Linux ARM (Raspberry Pi)..."
+echo "Vetting backend..."
 cd backend
-GOOS=linux GOARCH=arm GOARM=5 go build -o ../deploy/brightlight
+go vet ./...
+
+echo "Building backend for Raspberry Pi 2B (linux/arm v7)..."
+GOOS=linux GOARCH=arm GOARM=7 go build -o ../deploy/brightlight .
 cd ..
 
 echo "Copying frontend build to deploy..."
@@ -17,4 +24,7 @@ rsync -a --delete frontend/build/ deploy/frontend/build/
 echo "Copying ui-config to deploy..."
 rsync -a --delete backend/ui-config/ deploy/backend/ui-config/
 
-echo "Done. Deploy directory is ready for scp to Pi."
+echo "Copying systemd unit and installer to deploy..."
+cp packaging/brightlight.service packaging/install.sh deploy/
+
+echo "Done. Deploy directory matches the CI bundle layout, ready for scp to Pi."

--- a/readme.md
+++ b/readme.md
@@ -7,56 +7,81 @@ A lighting controller for pixel-addressable WS2811 LED strips intended for domes
 - **Teensy 3.x microcontroller** — generates LED strip waveforms (Arduino C, OctoWS2811)
 - **Go server on Raspberry Pi** — drives the Teensy over USB serial, serves the web UI
 - **React web app** — controls animations and button configuration
+- **Alexa voice control (optional)** — custom skill + AWS Lambda calling the server over HTTPS
 
 ## Repository layout
 
 ```
 frontend/   React 19 + Vite 8 web app
-backend/    Go server
+backend/    Go server (stdlib only)
+alexa/      Alexa custom skill: interaction model + AWS Lambda (see alexa/readme.md)
 firmware/   Arduino/Teensy C firmware (OctoWS2811)
+packaging/  systemd unit + Pi installer bundled by CI
 deploy/     Build output staging area for Pi deployment (see deploy/README.md)
+docs/       Design notes
 ```
 
 ## Building
 
-Run `full-build.bat` from the repo root (Windows). This:
-1. Builds the React frontend (`frontend/`) with Vite
-2. Cross-compiles the Go backend for Linux ARM (Raspberry Pi)
-3. Copies artefacts to `deploy/`
+### CI (GitHub Actions)
+
+`.github/workflows/build.yml` runs on every push and pull request to `master`
+or `develop`:
+
+1. Vets and cross-compiles the Go backend for Raspberry Pi 2B
+   (`GOOS=linux GOARCH=arm GOARM=7`)
+2. Builds the React frontend with Vite (`npm ci && npm run build`)
+3. On push, packages the binary, frontend build, ui-config, systemd unit and
+   installer into `brightlight-pi.tar.gz` and republishes it as the rolling
+   `latest` GitHub release
+
+### Local build
+
+Run `full-build.sh` (Linux/macOS) or `full-build.bat` (Windows) from the repo
+root. It performs the same steps as CI and stages the artefacts in `deploy/`
+(see `deploy/README.md` for deploying a local build manually).
 
 ## Setting up a new Pi
 
 1. Flash Raspberry Pi OS Lite, enable SSH
-2. SSH in: `ssh pi@192.168.0.XXX`
-3. Configure autostart in `/etc/rc.local`:
+2. SSH in and run the installer:
    ```bash
-   export BRIGHTLIGHT=/home/pi
-   /home/pi/brightlight > /dev/null 2>&1 &
+   curl -fsSL https://github.com/andew42/brightlight/releases/latest/download/install.sh | sudo bash
    ```
-4. Run `full-build.bat` on your PC
-5. Deploy to Pi:
-   ```bash
-   scp ./deploy/brightlight pi@192.168.0.XXX:/home/pi/brightlight
-   scp -r ./deploy/frontend/build pi@192.168.0.XXX:/home/pi/frontend/build
-   ssh pi@192.168.0.XXX "sudo chmod +x /home/pi/brightlight && sudo reboot"
-   ```
+   Append `-s -- --site bedroom` to select the hardware site layout
+   (default `titania`; the choice is remembered across upgrades).
+
+This downloads the latest CI build, installs it to `/opt/brightlight` and sets
+up the `brightlight` systemd service so it starts on boot. Re-run the same
+command to upgrade; user button edits (`user-buttons.json`) are preserved.
+
+Useful commands on the Pi:
+
+```bash
+systemctl status brightlight       # service state
+journalctl -u brightlight -f       # follow logs
+sudo systemctl restart brightlight
+```
+
+The web UI is served on port 8080.
 
 ## Development environment
 
-- Go 1.17+ — https://golang.org/dl/
+- Go 1.26+ — https://golang.org/dl/
 - Node.js 20+ — https://nodejs.org/
 - JetBrains GoLand / IntelliJ — open `frontend/` and `backend/` as separate projects
+
+### Backend dev server
+```bash
+cd backend
+go run .     # API at http://localhost:8080 (static content needs BRIGHTLIGHT set)
+```
 
 ### Frontend dev server
 ```bash
 cd frontend
 npm install
-npm start    # dev server at http://localhost:5173, proxies API to device
-```
-
-### Kill running instance on Pi
-```bash
-sudo killall -q -9 brightlight
+npm start    # dev server at http://localhost:5173, proxies /api to localhost:8080
 ```
 
 ## Setting up Arduino / Teensy environment
@@ -68,8 +93,5 @@ sudo killall -q -9 brightlight
 ## To Do
 
 - Candle animation
-- Fairground light chasers
-- Static string (Gazebo lights)
 - Clock animation
 - Fade between animations
-- Support for Alexa


### PR DESCRIPTION
- CLAUDE.md: add alexa/, packaging/, docs/ and CI workflow to the repo
  layout; document Alexa endpoints, BRIGHTLIGHT_ALEXA_* env vars, the
  /opt/brightlight install layout, and new gotcha entries for the Alexa
  integration and the CI/one-command Pi install
- readme.md: replace the old scp + /etc/rc.local deployment with the
  rolling-release installer and systemd service, describe the CI
  pipeline, refresh the repo layout and toolchain versions, and prune
  completed To Do items (Alexa, fairground, static string)
- full-build.sh/.bat: align with .github/workflows/build.yml — GOARM=7
  (Pi 2B) instead of GOARM=5, npm ci before the Vite build, go vet
  before compiling, and stage packaging/brightlight.service +
  install.sh so deploy/ matches the CI bundle layout
- deploy/README.md: document the extra staged files and matching layout

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BeYfhNszzdS9TtKviN13Y9