### PR TITLE
Add Plasma and Lava Lamp animations to titania static data

### DIFF
--- a/backend/ui-config/static-data-titania.json
+++ b/backend/ui-config/static-data-titania.json
@@ -53,6 +53,21 @@
     ]
     },
     {
+      "name": "Plasma", "params": [
+      {"key": 130, "type": "range", "label": "Speed", "min": 1, "max": 10, "value": 3},
+      {"key": 131, "type": "range", "label": "Brightness", "min": 10, "max": 50, "value": 40},
+      {"key": 132, "type": "range", "label": "Palette(0-3)", "min": 0, "max": 3, "value": 1}
+    ]
+    },
+    {
+      "name": "Lava Lamp", "params": [
+      {"key": 140, "type": "colour", "label": "Blob Colour", "value": {"r": 255, "g": 16, "b": 0}},
+      {"key": 141, "type": "colour", "label": "Background", "value": {"r": 48, "g": 0, "b": 64}},
+      {"key": 142, "type": "range", "label": "Speed", "min": 1, "max": 10, "value": 3},
+      {"key": 143, "type": "range", "label": "Blobs", "min": 1, "max": 12, "value": 5}
+    ]
+    },
+    {
       "name": "Life", "params": [
       {"key": 120, "type": "colour", "label": "Colour", "value": {"r": 128, "g": 128, "b": 128}},
       {"key": 121, "type": "range", "label": "Duration(frames)", "min": 1, "max": 100, "value": 25},


### PR DESCRIPTION
The titania site variant of static-data.json was missing the Plasma
and Lava Lamp animation definitions, so neither appeared in the
animations dropdown on a default (titania) install even though the
backend supports both. Copy the entries from the generic
static-data.json.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S79fb5aQNN7wKDFsfrwtYK