### PR TITLE
Fix missing titania animations, harden Pi installer, enlarge swipe dead area

### DIFF
--- a/backend/ui-config/static-data-titania.json
+++ b/backend/ui-config/static-data-titania.json
@@ -53,6 +53,21 @@
     ]
     },
     {
+      "name": "Plasma", "params": [
+      {"key": 130, "type": "range", "label": "Speed", "min": 1, "max": 10, "value": 3},
+      {"key": 131, "type": "range", "label": "Brightness", "min": 10, "max": 50, "value": 40},
+      {"key": 132, "type": "range", "label": "Palette(0-3)", "min": 0, "max": 3, "value": 1}
+    ]
+    },
+    {
+      "name": "Lava Lamp", "params": [
+      {"key": 140, "type": "colour", "label": "Blob Colour", "value": {"r": 255, "g": 16, "b": 0}},
+      {"key": 141, "type": "colour", "label": "Background", "value": {"r": 48, "g": 0, "b": 64}},
+      {"key": 142, "type": "range", "label": "Speed", "min": 1, "max": 10, "value": 3},
+      {"key": 143, "type": "range", "label": "Blobs", "min": 1, "max": 12, "value": 5}
+    ]
+    },
+    {
       "name": "Life", "params": [
       {"key": 120, "type": "colour", "label": "Colour", "value": {"r": 128, "g": 128, "b": 128}},
       {"key": 121, "type": "range", "label": "Duration(frames)", "min": 1, "max": 100, "value": 25},

--- a/frontend/src/buttons/ButtonPad.css
+++ b/frontend/src/buttons/ButtonPad.css
@@ -13,7 +13,7 @@
     /* Dead area below the bottom button row so the iOS swipe-up home
        gesture doesn't trigger a button (.App's safe-area-inset-bottom
        alone isn't enough — the swipe registers a touch above it) */
-    padding-bottom: 38px;
+    padding-bottom: 76px;
     background-color: purple;
 }
 

--- a/packaging/brightlight.service
+++ b/packaging/brightlight.service
@@ -9,6 +9,9 @@ WorkingDirectory=/opt/brightlight
 ExecStart=/opt/brightlight/brightlight
 Restart=always
 RestartSec=5
+# Don't let a wedged binary (e.g. blocked on USB serial) stall
+# `systemctl stop` for the 90s default before SIGKILL
+TimeoutStopSec=10
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -17,70 +17,93 @@
 
 set -euo pipefail
 
-REPO="andew42/brightlight"
-INSTALL_DIR="/opt/brightlight"
-TARBALL_URL="https://github.com/${REPO}/releases/latest/download/brightlight-pi.tar.gz"
-USER_BUTTONS="${INSTALL_DIR}/backend/ui-config/user-buttons.json"
-DROPIN_DIR="/etc/systemd/system/brightlight.service.d"
+main() {
+    REPO="andew42/brightlight"
+    INSTALL_DIR="/opt/brightlight"
+    TARBALL_URL="https://github.com/${REPO}/releases/latest/download/brightlight-pi.tar.gz"
+    USER_BUTTONS="${INSTALL_DIR}/backend/ui-config/user-buttons.json"
+    DROPIN_DIR="/etc/systemd/system/brightlight.service.d"
 
-SITE="${BRIGHTLIGHT_SITE:-}"
-while [ $# -gt 0 ]; do
-    case "$1" in
-        --site) SITE="${2:-}"; shift 2 ;;
-        --site=*) SITE="${1#*=}"; shift ;;
-        *) echo "Unknown option: $1" >&2; exit 1 ;;
-    esac
-done
-if [ -n "${SITE}" ] && [ "${SITE}" != "titania" ] && [ "${SITE}" != "bedroom" ]; then
-    echo "Invalid --site '${SITE}' (expected titania or bedroom)" >&2
-    exit 1
-fi
+    SITE="${BRIGHTLIGHT_SITE:-}"
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --site) SITE="${2:-}"; shift 2 ;;
+            --site=*) SITE="${1#*=}"; shift ;;
+            *) echo "Unknown option: $1" >&2; exit 1 ;;
+        esac
+    done
+    if [ -n "${SITE}" ] && [ "${SITE}" != "titania" ] && [ "${SITE}" != "bedroom" ]; then
+        echo "Invalid --site '${SITE}' (expected titania or bedroom)" >&2
+        exit 1
+    fi
 
-if [ "$(id -u)" -ne 0 ]; then
-    echo "This installer needs root. Re-run with: curl -fsSL ${TARBALL_URL%brightlight-pi.tar.gz}install.sh | sudo bash" >&2
-    exit 1
-fi
+    if [ "$(id -u)" -ne 0 ]; then
+        echo "This installer needs root. Re-run with: curl -fsSL ${TARBALL_URL%brightlight-pi.tar.gz}install.sh | sudo bash" >&2
+        exit 1
+    fi
 
-echo "Stopping brightlight service (if running)..."
-systemctl stop brightlight 2>/dev/null || true
+    WORK="$(mktemp -d)"
+    trap 'rm -rf "${WORK}"' EXIT
 
-# Preserve user-edited buttons across upgrades
-BUTTONS_BACKUP=""
-if [ -f "${USER_BUTTONS}" ]; then
-    BUTTONS_BACKUP="$(mktemp)"
-    cp "${USER_BUTTONS}" "${BUTTONS_BACKUP}"
-    echo "Preserving existing user-buttons.json"
-fi
+    # Download before touching anything so a slow or failed download can
+    # never leave the service stopped or the install half-replaced
+    echo "Downloading ${TARBALL_URL} ..."
+    curl -fsSL --retry 4 --retry-delay 2 -o "${WORK}/brightlight-pi.tar.gz" "${TARBALL_URL}"
 
-echo "Downloading ${TARBALL_URL} ..."
-mkdir -p "${INSTALL_DIR}"
-curl -fsSL "${TARBALL_URL}" | tar -xz -C "${INSTALL_DIR}"
-chmod +x "${INSTALL_DIR}/brightlight"
+    # Preserve user-edited buttons across upgrades
+    if [ -f "${USER_BUTTONS}" ]; then
+        cp "${USER_BUTTONS}" "${WORK}/user-buttons.json"
+        echo "Preserving existing user-buttons.json"
+    fi
 
-if [ -n "${BUTTONS_BACKUP}" ]; then
-    mv "${BUTTONS_BACKUP}" "${USER_BUTTONS}"
-fi
+    # Stop the service, but never let it stall the install: units installed
+    # before TimeoutStopSec was added can hang `systemctl stop` for minutes
+    # if the binary is wedged, so give it 15s then SIGKILL and move on
+    echo "Stopping brightlight service (if running)..."
+    if ! timeout 15 systemctl stop brightlight 2>/dev/null; then
+        echo "Service did not stop within 15s; killing it"
+        systemctl kill -s SIGKILL brightlight 2>/dev/null || true
+        sleep 1
+    fi
 
-echo "Installing systemd service..."
-cp "${INSTALL_DIR}/brightlight.service" /etc/systemd/system/brightlight.service
+    # --unlink-first so extraction still succeeds if the old binary is
+    # somehow running (overwriting a running executable in place fails
+    # with "Text file busy")
+    echo "Installing to ${INSTALL_DIR} ..."
+    mkdir -p "${INSTALL_DIR}"
+    tar -xz --unlink-first -f "${WORK}/brightlight-pi.tar.gz" -C "${INSTALL_DIR}"
+    chmod +x "${INSTALL_DIR}/brightlight"
 
-if [ -n "${SITE}" ]; then
-    echo "Setting site layout to '${SITE}'"
-    mkdir -p "${DROPIN_DIR}"
-    printf '[Service]\nEnvironment=BRIGHTLIGHT_SITE=%s\n' "${SITE}" > "${DROPIN_DIR}/site.conf"
-elif [ -f "${DROPIN_DIR}/site.conf" ]; then
-    echo "Keeping existing site layout: $(grep -o 'BRIGHTLIGHT_SITE=.*' "${DROPIN_DIR}/site.conf")"
-else
-    echo "No --site given; using built-in default (titania)"
-fi
+    if [ -f "${WORK}/user-buttons.json" ]; then
+        cp "${WORK}/user-buttons.json" "${USER_BUTTONS}"
+    fi
 
-systemctl daemon-reload
-systemctl enable brightlight
-systemctl start brightlight
+    echo "Installing systemd service..."
+    cp "${INSTALL_DIR}/brightlight.service" /etc/systemd/system/brightlight.service
 
-IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
-echo
-echo "Brightlight installed and running."
-echo "  Web UI:  http://${IP:-<pi-address>}:8080"
-echo "  Status:  systemctl status brightlight"
-echo "  Logs:    journalctl -u brightlight -f"
+    if [ -n "${SITE}" ]; then
+        echo "Setting site layout to '${SITE}'"
+        mkdir -p "${DROPIN_DIR}"
+        printf '[Service]\nEnvironment=BRIGHTLIGHT_SITE=%s\n' "${SITE}" > "${DROPIN_DIR}/site.conf"
+    elif [ -f "${DROPIN_DIR}/site.conf" ]; then
+        echo "Keeping existing site layout: $(grep -o 'BRIGHTLIGHT_SITE=.*' "${DROPIN_DIR}/site.conf")"
+    else
+        echo "No --site given; using built-in default (titania)"
+    fi
+
+    systemctl daemon-reload
+    systemctl enable brightlight
+    systemctl restart brightlight
+
+    IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+    echo
+    echo "Brightlight installed and running."
+    echo "  Web UI:  http://${IP:-<pi-address>}:8080"
+    echo "  Status:  systemctl status brightlight"
+    echo "  Logs:    journalctl -u brightlight -f"
+}
+
+# Wrapped in a function and invoked at the very end so that when the script
+# is streamed via `curl | bash` nothing executes until it has downloaded in
+# full — a dropped connection part-way can't run half an install
+main "$@"


### PR DESCRIPTION
Three fixes that came out of investigating why animations were missing from the dropdown on the Pi:

## Titania static data was missing Plasma and Lava Lamp

`static-data-titania.json` lacked the Plasma and Lava Lamp entries even though the backend supports both on every site, so a default (titania) install never showed them in the animations dropdown. Copied the entries from the generic `static-data.json`, keeping the same ordering (between Discrete and Life).

## Pi installer robustness

The installer could stall for minutes at "Stopping brightlight service" (the unit had no `TimeoutStopSec`, so a wedged binary held `systemctl stop` for systemd's 90s default and beyond), and because it streams via `curl | sudo bash` with the service already stopped, a dropped SSH connection part-way left the install half-done with stale files — observed in the field as an upgrade that updated the frontend but not the static data.

- Download the tarball to a temp dir (with curl retries) **before** stopping the service, so a failed download can't leave a broken install
- Bound the service stop to 15s with a SIGKILL fallback
- Extract with `tar --unlink-first` so a still-running old binary can't fail extraction with "Text file busy"
- Wrap the script in `main()` invoked at the end so a partially streamed script executes nothing
- Add `TimeoutStopSec=10` to the systemd unit

## Double the button pad bottom dead area

38px was still close enough to the bottom row for the iOS swipe-up home gesture to activate the bottom middle button; now 76px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S79fb5aQNN7wKDFsfrwtYK

---
_Generated by [Claude Code](https://claude.ai/code/session_01S79fb5aQNN7wKDFsfrwtYK)_