### PR TITLE
Run destructive install steps detached so a dropped SSH session can't break the upgrade

### DIFF
--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -14,17 +14,26 @@
 #
 # The choice is stored in a systemd drop-in and kept across upgrades; when no
 # site is given the existing choice (or the built-in default, titania) is kept.
+#
+# The install itself runs detached (setsid) once the download completes, so a
+# dropped SSH connection can't kill it part-way: on a Pi 2B the Ethernet is on
+# the USB bus, and a wedged USB serial port can take the network (and this
+# session) down while the old service is being stopped. Progress is logged to
+# /var/log/brightlight-install.log — check it after reconnecting if the
+# session drops.
 
 set -euo pipefail
 
 main() {
     REPO="andew42/brightlight"
-    INSTALL_DIR="/opt/brightlight"
     TARBALL_URL="https://github.com/${REPO}/releases/latest/download/brightlight-pi.tar.gz"
-    USER_BUTTONS="${INSTALL_DIR}/backend/ui-config/user-buttons.json"
-    DROPIN_DIR="/etc/systemd/system/brightlight.service.d"
+    LOG="/var/log/brightlight-install.log"
 
-    SITE="${BRIGHTLIGHT_SITE:-}"
+    export INSTALL_DIR="/opt/brightlight"
+    export USER_BUTTONS_NAME="backend/ui-config/user-buttons.json"
+    export DROPIN_DIR="/etc/systemd/system/brightlight.service.d"
+
+    export SITE="${BRIGHTLIGHT_SITE:-}"
     while [ $# -gt 0 ]; do
         case "$1" in
             --site) SITE="${2:-}"; shift 2 ;;
@@ -42,6 +51,8 @@ main() {
         exit 1
     fi
 
+    # Until the detached stage takes over, clean the work dir on any failure
+    export WORK
     WORK="$(mktemp -d)"
     trap 'rm -rf "${WORK}"' EXIT
 
@@ -51,59 +62,90 @@ main() {
     curl -fsSL --retry 4 --retry-delay 2 -o "${WORK}/brightlight-pi.tar.gz" "${TARBALL_URL}"
 
     # Preserve user-edited buttons across upgrades
-    if [ -f "${USER_BUTTONS}" ]; then
-        cp "${USER_BUTTONS}" "${WORK}/user-buttons.json"
+    if [ -f "${INSTALL_DIR}/${USER_BUTTONS_NAME}" ]; then
+        cp "${INSTALL_DIR}/${USER_BUTTONS_NAME}" "${WORK}/user-buttons.json"
         echo "Preserving existing user-buttons.json"
     fi
 
-    # Stop the service, but never let it stall the install: units installed
-    # before TimeoutStopSec was added can hang `systemctl stop` for minutes
-    # if the binary is wedged, so give it 15s then SIGKILL and move on
-    echo "Stopping brightlight service (if running)..."
-    if ! timeout 15 systemctl stop brightlight 2>/dev/null; then
-        echo "Service did not stop within 15s; killing it"
-        systemctl kill -s SIGKILL brightlight 2>/dev/null || true
-        sleep 1
-    fi
+    write_stage2 > "${WORK}/stage2.sh"
 
-    # --unlink-first so extraction still succeeds if the old binary is
-    # somehow running (overwriting a running executable in place fails
-    # with "Text file busy")
-    echo "Installing to ${INSTALL_DIR} ..."
-    mkdir -p "${INSTALL_DIR}"
-    tar -xz --unlink-first -f "${WORK}/brightlight-pi.tar.gz" -C "${INSTALL_DIR}"
-    chmod +x "${INSTALL_DIR}/brightlight"
+    # Hand work-dir ownership to the detached stage (it cleans up itself)
+    trap - EXIT
+    : > "${LOG}"
+    setsid bash "${WORK}/stage2.sh" </dev/null >>"${LOG}" 2>&1 &
+    STAGE2_PID=$!
 
-    if [ -f "${WORK}/user-buttons.json" ]; then
-        cp "${WORK}/user-buttons.json" "${USER_BUTTONS}"
-    fi
-
-    echo "Installing systemd service..."
-    cp "${INSTALL_DIR}/brightlight.service" /etc/systemd/system/brightlight.service
-
-    if [ -n "${SITE}" ]; then
-        echo "Setting site layout to '${SITE}'"
-        mkdir -p "${DROPIN_DIR}"
-        printf '[Service]\nEnvironment=BRIGHTLIGHT_SITE=%s\n' "${SITE}" > "${DROPIN_DIR}/site.conf"
-    elif [ -f "${DROPIN_DIR}/site.conf" ]; then
-        echo "Keeping existing site layout: $(grep -o 'BRIGHTLIGHT_SITE=.*' "${DROPIN_DIR}/site.conf")"
+    echo "Installing (detached; survives a dropped SSH session)..."
+    echo "Log: ${LOG}"
+    tail --pid="${STAGE2_PID}" -n +1 -f "${LOG}" 2>/dev/null || true
+    if wait "${STAGE2_PID}"; then
+        exit 0
     else
-        echo "No --site given; using built-in default (titania)"
+        echo "Install failed — see ${LOG}" >&2
+        exit 1
     fi
-
-    systemctl daemon-reload
-    systemctl enable brightlight
-    systemctl restart brightlight
-
-    IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
-    echo
-    echo "Brightlight installed and running."
-    echo "  Web UI:  http://${IP:-<pi-address>}:8080"
-    echo "  Status:  systemctl status brightlight"
-    echo "  Logs:    journalctl -u brightlight -f"
 }
 
-# Wrapped in a function and invoked at the very end so that when the script
-# is streamed via `curl | bash` nothing executes until it has downloaded in
+# The part that must not die with the SSH session: stopping the old service,
+# replacing the files and restarting. Runs via setsid with all state passed
+# in the environment (WORK, INSTALL_DIR, USER_BUTTONS_NAME, DROPIN_DIR, SITE).
+write_stage2() {
+    cat <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+trap 'rm -rf "${WORK}"' EXIT
+
+# Stop the service, but never let it stall the install: a binary wedged in
+# uninterruptible USB I/O can hang `systemctl stop` (and shrug off SIGKILL),
+# so bound the wait and carry on — extraction below copes with it running
+echo "Stopping brightlight service (if running)..."
+if ! timeout 15 systemctl stop brightlight 2>/dev/null; then
+    echo "Service did not stop within 15s; killing it"
+    systemctl kill -s SIGKILL brightlight 2>/dev/null || true
+    sleep 1
+fi
+
+# Remove the old binary first so extraction still succeeds if it is somehow
+# still running (writing over a running executable in place would fail with
+# "Text file busy"; GNU tar also unlinks regular files before extracting,
+# but be explicit rather than rely on it)
+echo "Installing to ${INSTALL_DIR} ..."
+mkdir -p "${INSTALL_DIR}"
+rm -f "${INSTALL_DIR}/brightlight"
+tar -xzf "${WORK}/brightlight-pi.tar.gz" -C "${INSTALL_DIR}"
+chmod +x "${INSTALL_DIR}/brightlight"
+
+if [ -f "${WORK}/user-buttons.json" ]; then
+    cp "${WORK}/user-buttons.json" "${INSTALL_DIR}/${USER_BUTTONS_NAME}"
+fi
+
+echo "Installing systemd service..."
+cp "${INSTALL_DIR}/brightlight.service" /etc/systemd/system/brightlight.service
+
+if [ -n "${SITE}" ]; then
+    echo "Setting site layout to '${SITE}'"
+    mkdir -p "${DROPIN_DIR}"
+    printf '[Service]\nEnvironment=BRIGHTLIGHT_SITE=%s\n' "${SITE}" > "${DROPIN_DIR}/site.conf"
+elif [ -f "${DROPIN_DIR}/site.conf" ]; then
+    echo "Keeping existing site layout: $(grep -o 'BRIGHTLIGHT_SITE=.*' "${DROPIN_DIR}/site.conf")"
+else
+    echo "No --site given; using built-in default (titania)"
+fi
+
+systemctl daemon-reload
+systemctl enable brightlight
+systemctl restart brightlight
+
+IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+echo
+echo "Brightlight installed and running."
+echo "  Web UI:  http://${IP:-<pi-address>}:8080"
+echo "  Status:  systemctl status brightlight"
+echo "  Logs:    journalctl -u brightlight -f"
+EOF
+}
+
+# Wrapped in functions invoked at the very end so that when the script is
+# streamed via `curl | bash` nothing executes until it has downloaded in
 # full — a dropped connection part-way can't run half an install
 main "$@"


### PR DESCRIPTION
Follow-up to #55 after field testing showed the installer still failing on the Pi.

## What was observed

With the #55 installer, the bounded stop fired ("Service did not stop within 15s; killing it") but the install then hung and the SSH session dropped, same as before. A process that survives SIGKILL is stuck in an uninterruptible kernel wait — i.e. wedged USB serial I/O — and on a Pi 2B the Ethernet adapter shares the USB bus, so the wedge takes the network down with it. That kills the `curl | sudo bash` session and everything under it, including tar mid-extraction, which is how earlier upgrades ended up half-applied (new frontend, stale ui-config).

## Changes

- Split the install: download and user-buttons backup run in the foreground, then the destructive stage (stop service, extract, restore buttons, install unit, restart) runs via `setsid`, fully detached from the terminal, logging to `/var/log/brightlight-install.log`. The foreground script tails the log so the interactive experience is unchanged, but if the SSH session dies the detached stage completes the upgrade regardless.
- Drop `tar --unlink-first` (introduced in #55): GNU tar fails to unlink existing non-empty directories with that flag, aborting the upgrade *after* the bundle's default `user-buttons.json` was extracted but *before* the user's backup was restored — i.e. it would have lost user button edits. Caught in sandbox testing before release. Plain GNU tar already unlinks regular files before extracting; the old binary is additionally removed explicitly before extraction as cheap insurance against "text file busy".

## Testing

Sandboxed end-to-end run with a stubbed `systemctl stop` that hangs forever: install completes via the SIGKILL fallback, user buttons preserved, site drop-in written, work dir cleaned up. Repeated with the foreground script SIGHUP'd and SIGKILL'd mid-run (simulating the SSH drop): the detached stage still completed the full install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S79fb5aQNN7wKDFsfrwtYK

---
_Generated by [Claude Code](https://claude.ai/code/session_01S79fb5aQNN7wKDFsfrwtYK)_