### PR TITLE
Install files before touching the service and watchdog-guard the restart

### DIFF
--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -86,29 +86,26 @@ main() {
     fi
 }
 
-# The part that must not die with the SSH session: stopping the old service,
-# replacing the files and restarting. Runs via setsid with all state passed
-# in the environment (WORK, INSTALL_DIR, USER_BUTTONS_NAME, DROPIN_DIR, SITE).
+# The part that must not die with the SSH session: replacing the files and
+# restarting the service. Runs via setsid with all state passed in the
+# environment (WORK, INSTALL_DIR, USER_BUTTONS_NAME, DROPIN_DIR, SITE).
+#
+# Ordering matters: killing a brightlight binary wedged in uninterruptible
+# USB serial I/O has been seen to freeze the whole kernel (dwc_otg IRQ
+# storm — on a Pi 2B the Ethernet and everything else goes with it, and
+# un-synced writes are lost on the power cycle). So install and sync ALL
+# files BEFORE touching the running service, and arm the hardware watchdog
+# around the restart so a frozen kernel hard-resets into the new install
+# instead of sitting dead until someone pulls the plug.
 write_stage2() {
     cat <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 trap 'rm -rf "${WORK}"' EXIT
 
-# Stop the service, but never let it stall the install: a binary wedged in
-# uninterruptible USB I/O can hang `systemctl stop` (and shrug off SIGKILL),
-# so bound the wait and carry on — extraction below copes with it running
-echo "Stopping brightlight service (if running)..."
-if ! timeout 15 systemctl stop brightlight 2>/dev/null; then
-    echo "Service did not stop within 15s; killing it"
-    systemctl kill -s SIGKILL brightlight 2>/dev/null || true
-    sleep 1
-fi
-
-# Remove the old binary first so extraction still succeeds if it is somehow
-# still running (writing over a running executable in place would fail with
-# "Text file busy"; GNU tar also unlinks regular files before extracting,
-# but be explicit rather than rely on it)
+# Install everything first, with the old service still running. The old
+# binary is unlinked (not overwritten) so the running process is untouched;
+# it keeps executing the old inode until we restart it below
 echo "Installing to ${INSTALL_DIR} ..."
 mkdir -p "${INSTALL_DIR}"
 rm -f "${INSTALL_DIR}/brightlight"
@@ -134,7 +131,41 @@ fi
 
 systemctl daemon-reload
 systemctl enable brightlight
-systemctl restart brightlight
+
+# Everything the new install needs is now on disk — flush it (log included)
+# so nothing is lost even if restarting the old service freezes the kernel
+echo "Files installed. Restarting the service..."
+echo "(If the Pi freezes or reboots at this point the install has still"
+echo " completed — after the reboot it will be running the new version)"
+sync
+
+# Arm the hardware watchdog: opening /dev/watchdog starts a ~15s countdown
+# that hard-resets the Pi unless petted, and a background petter keeps it
+# at bay. If killing the wedged old process freezes the kernel, the petter
+# freezes too and the watchdog reboots us into the new install
+WD_PET=""
+if [ -w /dev/watchdog ]; then
+    exec 3>/dev/watchdog
+    ( while true; do printf '.' >&3; sleep 5; done ) &
+    WD_PET=$!
+fi
+
+if ! timeout 30 systemctl restart brightlight; then
+    echo "Service restart timed out (old process wedged); forcing a reboot"
+    sync
+    # Stop petting but leave the watchdog armed: if even the forced reboot
+    # freezes, it hard-resets the Pi within ~15s anyway
+    [ -n "${WD_PET}" ] && kill "${WD_PET}" 2>/dev/null
+    systemctl --force --force reboot || echo b > /proc/sysrq-trigger
+    exit 0
+fi
+
+# Healthy restart — disarm the watchdog ('V' magic close stops the countdown)
+if [ -n "${WD_PET}" ]; then
+    kill "${WD_PET}" 2>/dev/null || true
+    printf 'V' >&3
+    exec 3>&-
+fi
 
 IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
 echo


### PR DESCRIPTION
Follow-up to #56. Field testing showed the detached installer still lost the upgrade: after the freeze and power cycle, `/var/log/brightlight-install.log` did not exist at all. The log file is created before anything else, so its absence means the kernel froze before *any* writes committed to the SD card — killing the old binary wedged in USB serial I/O freezes the whole Pi (dwc_otg IRQ storm: Ethernet, disk commits and the detached stage all die together, and un-synced page-cache writes are lost on the power cycle). Detaching from SSH isn't enough when the OS itself dies.

## Changes

Reorder stage 2 so the upgrade is complete and durable *before* anything risky happens:

- Extract the bundle, restore user buttons, install the systemd unit and site drop-in **with the old service still running**. The old binary is unlinked rather than overwritten, so the running process is untouched (it keeps executing the old inode). Then `sync`, so everything — log included — is on disk.
- Only then restart the service, with the Pi's hardware watchdog armed and a background petter. If killing the old process freezes the kernel, the petter freezes with it and the watchdog hard-resets the Pi within ~15s — straight into the already-installed new version (the service is enabled, so it starts on boot).
- If the restart merely times out without freezing the kernel, force an immediate reboot (`systemctl --force --force reboot`, sysrq-b as fallback), leaving the watchdog armed as a backstop in case even that freezes.
- On a healthy restart the watchdog is disarmed with the magic-close (`V`) and the installer finishes normally.

## Testing

Sandboxed with stubbed `systemctl`/watchdog device:

- Healthy restart: watchdog armed, petted, disarmed with `V`; user buttons preserved; site drop-in written; work dir cleaned.
- Wedged restart (restart hangs): files and static data verified installed and synced before the forced reboot fires; petter stopped without disarming so the watchdog stays as backstop.

Worst case on a wedged Pi is now: install completes → restart freezes kernel → watchdog resets → Pi boots running the new version, with the install log intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S79fb5aQNN7wKDFsfrwtYK

---
_Generated by [Claude Code](https://claude.ai/code/session_01S79fb5aQNN7wKDFsfrwtYK)_