### PR TITLE
Tolerate a busy or absent hardware watchdog during install

### DIFF
--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -142,12 +142,16 @@ sync
 # Arm the hardware watchdog: opening /dev/watchdog starts a ~15s countdown
 # that hard-resets the Pi unless petted, and a background petter keeps it
 # at bay. If killing the wedged old process freezes the kernel, the petter
-# freezes too and the watchdog reboots us into the new install
+# freezes too and the watchdog reboots us into the new install.
+# The open fails with EBUSY when something already owns the watchdog
+# (e.g. systemd's RuntimeWatchdogSec) — that's fine: the existing owner
+# provides the same freeze protection, so continue without it
 WD_PET=""
-if [ -w /dev/watchdog ]; then
-    exec 3>/dev/watchdog
+if { exec 3>/dev/watchdog; } 2>/dev/null; then
     ( while true; do printf '.' >&3; sleep 5; done ) &
     WD_PET=$!
+else
+    echo "Hardware watchdog unavailable (absent or already in use); continuing without it"
 fi
 
 if ! timeout 30 systemctl restart brightlight; then


### PR DESCRIPTION
Follow-up to #57, from the first field run of the watchdog installer:

```
/tmp/tmp.2mJ9ScegaC/stage2.sh: line 47: /dev/watchdog: Device or resource busy
```

The watchdog device allows only one opener, and on this Pi something already owns it (most likely systemd's `RuntimeWatchdogSec`). Under `set -e` the failed `exec` aborted stage 2 **after** the files were installed and synced but **before** the service restart — leaving the old version running until the next reboot.

Guard the open (`{ exec 3>/dev/watchdog; } 2>/dev/null`) and continue without our own watchdog when it's busy or absent, logging that fact. An existing owner like systemd's runtime watchdog provides the same protection anyway: if the kernel freezes during the service restart, PID 1 stops petting and the hardware resets the Pi into the already-installed new version.

Sandbox-tested both paths: unopenable watchdog → fallback message and normal completion; openable watchdog → armed, petted, disarmed with the `V` magic close as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S79fb5aQNN7wKDFsfrwtYK

---
_Generated by [Claude Code](https://claude.ai/code/session_01S79fb5aQNN7wKDFsfrwtYK)_