### PR TITLE
Shut down serial drivers cleanly on SIGTERM and bound Teensy writes

### DIFF
--- a/backend/controller/flush_linux.go
+++ b/backend/controller/flush_linux.go
@@ -1,0 +1,14 @@
+//go:build linux
+
+package controller
+
+import "syscall"
+
+// tcflush(fd, TCOFLUSH): discard output that has been written to the tty
+// but not yet transmitted. Values from asm-generic/ioctls.h and termios.h
+func flushOutputQueue(fd uintptr) {
+
+	const TCFLSH = 0x540B
+	const TCOFLUSH = 1
+	_, _, _ = syscall.Syscall(syscall.SYS_IOCTL, fd, TCFLSH, TCOFLUSH)
+}

--- a/backend/controller/flush_other.go
+++ b/backend/controller/flush_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package controller
+
+// Output queue flushing is only implemented for Linux (the deployment
+// target); elsewhere closing the port without it is fine for development
+func flushOutputQueue(fd uintptr) {
+}

--- a/backend/controller/relay.go
+++ b/backend/controller/relay.go
@@ -24,6 +24,7 @@ func StartRelayDriver() {
 	relayDriverStarted = true
 
 	// Start driver
+	shutdownWaitGroup.Add(1)
 	go relayDriver()
 }
 
@@ -36,6 +37,8 @@ var relayUsbConnected atomic.Bool
 
 // Monitors changes to frame buffer and turns power supplies on or off via USB relay board
 func relayDriver() {
+
+	defer shutdownWaitGroup.Done()
 
 	port := getPortName(relayPortMappings, 0)
 	if port == "" {
@@ -54,6 +57,10 @@ connectLoop:
 	for {
 		relayUsbConnected.Store(false)
 		f := openUsbPortWithRetry(port)
+		if f == nil {
+			// Shutdown requested while waiting for the port
+			return
+		}
 		relayUsbConnected.Store(true)
 
 		// Initially we set all relays off
@@ -69,7 +76,14 @@ connectLoop:
 		// Push frame buffer changes to the relay board
 	pushLoop:
 		for {
-			fb := <-src
+			var fb *framebuffer.FrameBuffer
+			select {
+			case fb = <-src:
+			case <-shutdownChan:
+				// Quiesced close: no writes in progress, queue flushed
+				closePortQuiesced(f)
+				return
+			}
 			now := time.Now()
 			// foreach controller
 			controllerCount := len(fb.Strips) / config.StripsPerTeensy

--- a/backend/controller/shutdown.go
+++ b/backend/controller/shutdown.go
@@ -1,0 +1,48 @@
+package controller
+
+import (
+	"os"
+	"sync"
+	"time"
+
+	"log/slog"
+)
+
+// Closed by Shutdown to ask the driver go routines to quiesce and close
+// their USB serial ports
+var shutdownChan = make(chan struct{})
+
+// Tracks driver go routines that have not yet finished shutting down
+var shutdownWaitGroup sync.WaitGroup
+
+// Shutdown asks the Teensy and relay drivers to stop writing, flush and
+// close their USB serial ports, then waits for them (up to timeout).
+// Exiting without this leaves the kernel to tear down a tty that may
+// have a full output queue and USB transfers in flight; on a Raspberry
+// Pi that has been seen to wedge the dwc_otg USB controller and freeze
+// the whole machine (the Ethernet is on the same USB bus)
+func Shutdown(timeout time.Duration) {
+
+	close(shutdownChan)
+	done := make(chan struct{})
+	go func() {
+		shutdownWaitGroup.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		slog.Info("controller drivers shut down cleanly")
+	case <-time.After(timeout):
+		slog.Warn("controller driver shutdown timed out")
+	}
+}
+
+// Discard any unsent output then close the port, so the tty is torn
+// down with an empty queue
+func closePortQuiesced(f *os.File) {
+
+	flushOutputQueue(f.Fd())
+	if err := f.Close(); err != nil {
+		slog.Warn("closePortQuiesced failed to close port", "error", err.Error())
+	}
+}

--- a/backend/controller/teensy.go
+++ b/backend/controller/teensy.go
@@ -23,6 +23,7 @@ func StartTeensyDriver() {
 	teensyDriverStarted = true
 
 	// Start 2 sub drivers (16 channels)
+	shutdownWaitGroup.Add(2)
 	go teensyDriver(0)
 	go teensyDriver(1)
 }
@@ -36,8 +37,17 @@ func TeensyConnections() []bool {
 
 var teensyConnections [2]atomic.Bool
 
+// How long a frame write to the Teensy may take before we treat the
+// connection as dead. A healthy frame takes a few ms at 12Mb USB speed;
+// a Teensy that has crashed or stopped draining its serial input would
+// otherwise block the write forever with a full kernel tty queue —
+// exactly the state that wedges the Pi's USB controller on process exit
+const teensyWriteTimeout = 2 * time.Second
+
 // Monitors changes to frame buffer and update Teensy via USB
 func teensyDriver(driverIndex int) {
+
+	defer shutdownWaitGroup.Done()
 
 	port := getPortName(teensyPortMappings, driverIndex)
 	if port == "" {
@@ -48,6 +58,10 @@ func teensyDriver(driverIndex int) {
 	for {
 		teensyConnections[driverIndex].Store(false)
 		f := openUsbPortWithRetry(port)
+		if f == nil {
+			// Shutdown requested while waiting for the port
+			return
+		}
 		teensyConnections[driverIndex].Store(true)
 
 		// Allocate buffer once to avoid garbage collections in loop
@@ -58,7 +72,14 @@ func teensyDriver(driverIndex int) {
 
 		// Push frame buffer changes to Teensy
 		for {
-			fb := <-src
+			var fb *framebuffer.FrameBuffer
+			select {
+			case fb = <-src:
+			case <-shutdownChan:
+				// Quiesced close: no writes in progress, queue flushed
+				closePortQuiesced(f)
+				return
+			}
 
 			// Skip if the frame buffer has no strips for this Teensy
 			// (e.g. a single Teensy configuration with a second port present)
@@ -108,9 +129,12 @@ func teensyDriver(driverIndex int) {
 				i++
 			}
 
+			// Bound the write; ignore the error as not all platforms
+			// support deadlines on serial ports (Linux does)
+			_ = f.SetWriteDeadline(time.Now().Add(teensyWriteTimeout))
 			if _, err := f.Write(data); err != nil {
 				slog.Warn("teensyDriver send failed", "error", err.Error())
-				f.Close()
+				closePortQuiesced(f)
 
 				// Close down listener then try and reconnect
 				done <- src

--- a/backend/controller/usbserial.go
+++ b/backend/controller/usbserial.go
@@ -43,11 +43,16 @@ func getPortName(portMappings map[string][]string, index int) string {
 	return portNames[index]
 }
 
-// Retry port open until it succeeds
+// Retry port open until it succeeds, or nil once shutdown is requested
 func openUsbPortWithRetry(port string) *os.File {
 
 	errorLogged := false
 	for {
+		select {
+		case <-shutdownChan:
+			return nil
+		default:
+		}
 		f, err := os.OpenFile(port, os.O_RDWR, 0)
 		if err == nil {
 			slog.Info("openUsbPortWithRetry connected", "port", port)

--- a/backend/main.go
+++ b/backend/main.go
@@ -5,8 +5,11 @@ import (
 	"mime"
 	"net/http"
 	"os"
+	"os/signal"
 	"runtime"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/andew42/brightlight/animations"
 	"github.com/andew42/brightlight/config"
@@ -73,6 +76,20 @@ func main() {
 	// Start drivers
 	controller.StartTeensyDriver()
 	controller.StartRelayDriver()
+
+	// Shut down cleanly on SIGTERM (systemctl stop) or Ctrl-C: quiesce the
+	// serial drivers and close their ports before exiting. Dying mid-write
+	// leaves the kernel to tear down a tty with a full output queue, which
+	// has been seen to wedge the Pi's dwc_otg USB controller and freeze
+	// the whole machine (Ethernet shares that USB bus)
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		s := <-sigChan
+		slog.Info("shutting down", "signal", s.String())
+		controller.Shutdown(3 * time.Second)
+		os.Exit(0)
+	}()
 	renderer := make(chan *framebuffer.FrameBuffer)
 	framebuffer.StartDriver(renderer)
 	animations.StartDriver(renderer)


### PR DESCRIPTION
Root-cause investigation of why `systemctl stop brightlight` can wedge the whole Pi, plus the fix.

## Why the wedge happens

Three things compound:

1. **The binary has no shutdown handling.** `main.go` installs no signal handlers, so a `systemctl stop` kills the process mid-`Write()` of a 9.6KB frame to `/dev/ttyACM0`. Process death makes the *kernel* tear down the tty — cancelling in-flight USB transfers and discarding a potentially full output queue during exit.

2. **The Pi 2B's dwc_otg USB host controller is fragile under URB cancellation.** Tearing down a cdc-acm tty with transfers in flight is a known trigger for dwc_otg interrupt storms that freeze the entire machine. The Ethernet controller hangs off the same USB bus, which is why the network (and SSH) dies with it, and why disk commits stop (the observed lost install log). The freeze happens *after* SIGKILL is accepted — during kernel-side fd teardown — which is why the process appeared unkillable.

3. **A wedged Teensy makes the queue as full as possible.** `teensyDriver` writes with no deadline. The firmware always drains serial in normal operation (its `serial_read()` gives up after ~300ms and it resyncs on the `0xff` header), so a persistently non-draining Teensy means the firmware has crashed or hung (e.g. stuck in `leds.show()` waiting on a DMA-complete that never comes). When that happens the driver's write blocks forever against a stuffed kernel tty queue — the worst possible state for the eventual teardown. It also means the *old* unit (no `TimeoutStopSec`) hung `systemctl stop` for minutes.

## Changes

- **Clean shutdown**: SIGTERM/SIGINT now quiesce the Teensy and relay drivers — each finishes its current write, flushes the tty output queue (`tcflush(TCOFLUSH)`, Linux-only via build tag; no-op elsewhere) and closes its port — then the process exits. The tty is torn down with an empty queue and no writes in flight, removing the dwc_otg trigger from the normal stop path.
- **Bounded writes**: Teensy frame writes get a 2s `SetWriteDeadline`. A crashed/wedged Teensy now surfaces as `teensyDriver send failed` + reconnect loop instead of a forever-blocked write, so the service stays stoppable and the queue never sits full. (Deadline errors are ignored on platforms without pollable serial support.)
- `openUsbPortWithRetry` aborts once shutdown is requested, so drivers waiting on an absent device exit promptly too.

## Verification

- SIGTERM smoke test: logs `shutting down signal=terminated` then `controller drivers shut down cleanly`, exits in milliseconds (previously: only killable by default signal disposition mid-write).
- `go vet` clean; builds pass for linux/arm GOARM=7 (Pi), linux/amd64, darwin/arm64, windows/amd64.

## What this doesn't fix

If the Teensy firmware itself is wedging (status LED off/frozen lights while the server runs), that's the upstream fault to chase — this change makes the server detect and survive it rather than freeze the Pi. Worth checking `journalctl -u brightlight` for `teensyDriver send failed` / `failed to set stty raw mode` occurrences, and `dmesg` for USB errors after the next incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S79fb5aQNN7wKDFsfrwtYK

---
_Generated by [Claude Code](https://claude.ai/code/session_01S79fb5aQNN7wKDFsfrwtYK)_