### PR TITLE
Rename Lava Lamp to Lava, rescale speed and add a blob size slider

### DIFF
--- a/backend/animations/animate.go
+++ b/backend/animations/animate.go
@@ -205,7 +205,7 @@ func appendAnimatorsForAction(animators *[]segActionAndAnimator, seg SegmentActi
 			slog.Warn("Bad animation parameter", "params", seg.Params, "error", err.Error())
 		}
 
-	case "Lava Lamp":
+	case "Lava":
 		var err error
 		blobColour, err := seg.Params.asColour(0)
 		var background framebuffer.Rgb
@@ -220,12 +220,16 @@ func appendAnimatorsForAction(animators *[]segActionAndAnimator, seg SegmentActi
 		if err == nil {
 			blobCount, err = seg.Params.asRange(3)
 		}
-		if err == nil && (speed < 1 || blobCount < 1) {
-			err = errors.New("bad speed or blob count parameters")
+		var blobSize int
+		if err == nil {
+			blobSize, err = seg.Params.asRange(4)
+		}
+		if err == nil && (speed < 1 || blobCount < 1 || blobSize < 1) {
+			err = errors.New("bad speed, blob count or blob size parameters")
 		}
 		if err == nil {
 			*animators = append(*animators,
-				segActionAndAnimator{seg, newLava(blobColour, background, speed, blobCount)})
+				segActionAndAnimator{seg, newLava(blobColour, background, speed, blobCount, blobSize)})
 		} else {
 			slog.Warn("Bad animation parameter", "params", seg.Params, "error", err.Error())
 		}

--- a/backend/animations/lava.go
+++ b/backend/animations/lava.go
@@ -8,7 +8,7 @@ import (
 	"github.com/andew42/brightlight/segment"
 )
 
-// Lava lamp effect: distinct blobs of one colour drift slowly through a
+// Lava effect: distinct blobs of one colour drift slowly through a
 // background colour, merging and separating like wax in a lava lamp.
 // Each blob's position and size are driven by summed sine waves with
 // randomised frequencies and phases. The blobs contribute to a
@@ -42,7 +42,24 @@ func toFloat64Rgb(c framebuffer.Rgb) float64Rgb {
 	return float64Rgb{float64(c.Red), float64(c.Green), float64(c.Blue)}
 }
 
-func newLava(blobColour framebuffer.Rgb, background framebuffer.Rgb, speed int, blobCount int) *lava {
+// Speed 1..10 maps exponentially onto a drift rate. 10 is the fastest and
+// matches what used to be speed 5; 1 is ten times slower than the old
+// slowest setting so the lamp can be made to creep.
+const (
+	lavaSlowestRate = 0.02
+	lavaFastestRate = 1.0
+)
+
+func lavaSpeedRate(speed int) float64 {
+	if speed < 1 {
+		speed = 1
+	} else if speed > 10 {
+		speed = 10
+	}
+	return lavaSlowestRate * math.Pow(lavaFastestRate/lavaSlowestRate, float64(speed-1)/9)
+}
+
+func newLava(blobColour framebuffer.Rgb, background framebuffer.Rgb, speed int, blobCount int, blobSize int) *lava {
 
 	blobs := make([]lavaBlob, blobCount)
 	for i := range blobs {
@@ -60,10 +77,10 @@ func newLava(blobColour framebuffer.Rgb, background framebuffer.Rgb, speed int, 
 	return &lava{
 		blobColour: toFloat64Rgb(blobColour),
 		background: toFloat64Rgb(background),
-		// speed 1..10 scaled so mid values take tens of seconds per drift cycle
-		speed: float64(speed) * 0.2,
-		// Base blob radius as a fraction of the segment, smaller with more blobs
-		radius: 0.5 / float64(blobCount),
+		speed:      lavaSpeedRate(speed),
+		// Base blob radius as a fraction of the segment, smaller with more
+		// blobs, scaled by blob size 1..10 (5 is the natural size)
+		radius: 0.5 / float64(blobCount) * float64(blobSize) / 5.0,
 		blobs:  blobs,
 	}
 }

--- a/backend/ui-config/default-buttons.json
+++ b/backend/ui-config/default-buttons.json
@@ -145,17 +145,18 @@
     },
     {
       "key": 11,
-      "name": "Lava Lamp",
+      "name": "Lava",
       "segments": [
         {
           "name": "All",
           "z": 1,
-          "animation": "Lava Lamp",
+          "animation": "Lava",
           "params": [
             {"key": 140, "type": "colour", "label": "Blob Colour", "value": {"r": 255, "g": 16, "b": 0}},
             {"key": 141, "type": "colour", "label": "Background", "value": {"r": 48, "g": 0, "b": 64}},
-            {"key": 142, "type": "range", "label": "Speed", "min": 1, "max": 10, "value": 3},
-            {"key": 143, "type": "range", "label": "Blobs", "min": 1, "max": 12, "value": 5}
+            {"key": 142, "type": "range", "label": "Speed", "min": 1, "max": 10, "value": 8},
+            {"key": 143, "type": "range", "label": "Blobs", "min": 1, "max": 12, "value": 5},
+            {"key": 144, "type": "range", "label": "Blob Size", "min": 1, "max": 10, "value": 5}
           ]
         }
       ]

--- a/backend/ui-config/static-data-bedroom.json
+++ b/backend/ui-config/static-data-bedroom.json
@@ -37,11 +37,12 @@
       {"key":131, "type":"range", "label":"Brightness", "min":10, "max":50, "value":40},
       {"key":132, "type":"range", "label":"Palette(0-3)", "min":0, "max":3, "value":1}
     ]},
-    {"name":"Lava Lamp", "params":[
+    {"name":"Lava", "params":[
       {"key":140, "type":"colour", "label":"Blob Colour", "value":{"r":255, "g":16, "b":0}},
       {"key":141, "type":"colour", "label":"Background", "value":{"r":48, "g":0, "b":64}},
-      {"key":142, "type":"range", "label":"Speed", "min":1, "max":10, "value":3},
-      {"key":143, "type":"range", "label":"Blobs", "min":1, "max":12, "value":5}
+      {"key":142, "type":"range", "label":"Speed", "min":1, "max":10, "value":8},
+      {"key":143, "type":"range", "label":"Blobs", "min":1, "max":12, "value":5},
+      {"key":144, "type":"range", "label":"Blob Size", "min":1, "max":10, "value":5}
     ]},
     {"name":"Life", "params":[
       {"key":120, "type":"colour", "label":"Colour", "value":{"r":128, "g":128, "b":128}},

--- a/backend/ui-config/static-data-titania.json
+++ b/backend/ui-config/static-data-titania.json
@@ -60,11 +60,12 @@
     ]
     },
     {
-      "name": "Lava Lamp", "params": [
+      "name": "Lava", "params": [
       {"key": 140, "type": "colour", "label": "Blob Colour", "value": {"r": 255, "g": 16, "b": 0}},
       {"key": 141, "type": "colour", "label": "Background", "value": {"r": 48, "g": 0, "b": 64}},
-      {"key": 142, "type": "range", "label": "Speed", "min": 1, "max": 10, "value": 3},
-      {"key": 143, "type": "range", "label": "Blobs", "min": 1, "max": 12, "value": 5}
+      {"key": 142, "type": "range", "label": "Speed", "min": 1, "max": 10, "value": 8},
+      {"key": 143, "type": "range", "label": "Blobs", "min": 1, "max": 12, "value": 5},
+      {"key": 144, "type": "range", "label": "Blob Size", "min": 1, "max": 10, "value": 5}
     ]
     },
     {

--- a/backend/ui-config/static-data.json
+++ b/backend/ui-config/static-data.json
@@ -60,11 +60,12 @@
     ]
     },
     {
-      "name": "Lava Lamp", "params": [
+      "name": "Lava", "params": [
       {"key": 140, "type": "colour", "label": "Blob Colour", "value": {"r": 255, "g": 16, "b": 0}},
       {"key": 141, "type": "colour", "label": "Background", "value": {"r": 48, "g": 0, "b": 64}},
-      {"key": 142, "type": "range", "label": "Speed", "min": 1, "max": 10, "value": 3},
-      {"key": 143, "type": "range", "label": "Blobs", "min": 1, "max": 12, "value": 5}
+      {"key": 142, "type": "range", "label": "Speed", "min": 1, "max": 10, "value": 8},
+      {"key": 143, "type": "range", "label": "Blobs", "min": 1, "max": 12, "value": 5},
+      {"key": 144, "type": "range", "label": "Blob Size", "min": 1, "max": 10, "value": 5}
     ]
     },
     {


### PR DESCRIPTION
## What changed

**Renamed to "Lava".** The animation was called "Lava Lamp"; it is now "Lava" in the dispatcher case (`backend/animations/animate.go`), in all three static-data files and in the default button (whose own label changed too).

**Speed rescaled.** The 1..10 slider now maps exponentially onto the drift rate instead of linearly. The top of the slider equals what used to be speed 5, and the bottom is ten times slower than the old slowest setting:

| slider | new rate | old rate |
|---|---|---|
| 1 | 0.020 | 0.20 |
| 3 | 0.048 | 0.60 |
| 5 | 0.114 | 1.00 |
| 8 | 0.419 | 1.60 |
| 10 | 1.000 | 2.00 |

The default moves from 3 to 8. On the new scale the old default rate (0.6) sits at about 9; 8 is a shade slower, which suits the effect.

**New Blob Size slider.** A range parameter (key 144, 1..10, default 5) scales the base blob radius by `size/5`, so 5 reproduces the previous blobs, 1 gives fifth-size specks and 10 gives double-size blobs that merge much more readily. It is appended last so the existing parameter indices are untouched.

## Why

Requested: shorter name, the ability to run the effect much slower, and control over blob size.

## Reviewer notes

- No frontend changes — `LedSegmentEditor.jsx` renders parameters generically from the JSON, so the new slider appears on its own.
- **Deployment caveat:** any button in the device's live `user-buttons.json` that references the animation `"Lava Lamp"` will now log `Unknown animation action` and render nothing. Those buttons need re-picking in the editor to take the new name and the extra parameter. The repo's `user-buttons.json` has no such button — its "Plasma Lava Lamp" entry uses the Plasma animation and is untouched.
- `go vet` and `go build` are clean; all four config files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)